### PR TITLE
Add method to Streaming API which notifies about completed traces

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -61,6 +61,9 @@ func main() {
 	}
 	pusherBlockCh := source.Run(context.TODO())
 
+	tracer := sources.NewTracer(log, storage, source)
+	go tracer.Run(context.TODO())
+
 	idx, err := indexer.New(log, cfg.App.LiteServers)
 	if err != nil {
 		log.Fatal("failed to create blockchain indexer", zap.Error(err))
@@ -72,6 +75,7 @@ func main() {
 
 	server, err := api.NewServer(log, h, fmt.Sprintf(":%d", cfg.API.Port),
 		api.WithTransactionSource(source),
+		api.WithTraceSource(tracer),
 		api.WithMemPool(mempool))
 	if err != nil {
 		log.Fatal("failed to create api handler", zap.Error(err))

--- a/examples/golang/sse/main.go
+++ b/examples/golang/sse/main.go
@@ -68,7 +68,44 @@ func subscribeToTransactions() error {
 	return err
 }
 
+// TraceEventData represents a notification about a completed trace.
+type TraceEventData struct {
+	AccountIDs []tongo.AccountID `json:"accounts"`
+	Hash       string            `json:"hash"`
+}
+
+func subscribeToTraces() error {
+	client := sse.NewClient("https://tonapi.io/v2/sse/accounts/traces?accounts=-1:5555555555555555555555555555555555555555555555555555555555555555")
+	// When working with tonapi.io, you should consider getting an API key at https://tonconsole.com/
+	// because tonapi.io has per-ip limits for websocket.
+	// client.Headers["Authorization"] = "bearer API-KEY"
+	//
+	// To work with a local version of opentonapi use http://127.0.0.1:8081/v2/sse/accounts/transactions
+	//
+	err := client.Subscribe("", func(msg *sse.Event) {
+		switch string(msg.Event) {
+		case "heartbeat":
+			fmt.Printf("%v\n", string(msg.Event))
+		case "message":
+			data := TraceEventData{}
+			if err := json.Unmarshal(msg.Data, &data); err != nil {
+				fmt.Printf("json.Unmarshal() failed: %v, data: %#v", err, msg)
+				return
+			}
+			var accounts []string
+			for _, account := range data.AccountIDs {
+				accounts = append(accounts, account.ToRaw())
+			}
+			fmt.Printf("trace hash %v, accounts: %v\n", data.Hash, accounts)
+		}
+	})
+	return err
+}
+
 func main() {
+	if err := subscribeToTraces(); err != nil {
+		panic(err)
+	}
 	if err := subscribeToMempool(); err != nil {
 		panic(err)
 	}

--- a/examples/golang/websocket/main.go
+++ b/examples/golang/websocket/main.go
@@ -72,6 +72,16 @@ func main() {
 	if err = conn.WriteJSON(request); err != nil {
 		panic(err)
 	}
+	// subscribe to notifications about traces
+	request = JsonRPCRequest{
+		ID:      1,
+		JSONRPC: "2.0",
+		Method:  "subscribe_trace",
+		Params:  []string{"-1:5555555555555555555555555555555555555555555555555555555555555555"},
+	}
+	if err = conn.WriteJSON(request); err != nil {
+		panic(err)
+	}
 	// do nothing
 	select {}
 }

--- a/pkg/pusher/events/name.go
+++ b/pkg/pusher/events/name.go
@@ -7,6 +7,7 @@ type Name string
 const (
 	PingEvent      Name = "ping"
 	AccountTxEvent Name = "account-tx"
+	TraceEvent     Name = "trace"
 	MempoolEvent   Name = "mempool"
 )
 

--- a/pkg/pusher/sources/trace_dispatcher.go
+++ b/pkg/pusher/sources/trace_dispatcher.go
@@ -1,0 +1,111 @@
+package sources
+
+import (
+	"sync"
+
+	"github.com/tonkeeper/tongo"
+	"go.uber.org/zap"
+)
+
+// TraceDispatcher implements the fan-out pattern reading a TraceEvent from a single channel
+// and delivering it to multiple subscribers.
+type TraceDispatcher struct {
+	logger *zap.Logger
+
+	mu          sync.RWMutex
+	accounts    map[tongo.AccountID]map[subscriberID]DeliveryFn
+	allAccounts map[subscriberID]DeliveryFn
+	options     map[subscriberID]SubscribeToTraceOptions
+	currentID   subscriberID
+}
+
+// TraceEventData represents a notification about a completed trace.
+// This is part of our API contract with subscribers.
+type TraceEventData struct {
+	AccountIDs []tongo.AccountID `json:"accounts"`
+	Hash       string            `json:"hash"`
+}
+
+// NewTraceDispatcher creates a new instance of TraceDispatcher.
+func NewTraceDispatcher(logger *zap.Logger) *TraceDispatcher {
+	return &TraceDispatcher{
+		logger:      logger,
+		accounts:    map[tongo.AccountID]map[subscriberID]DeliveryFn{},
+		allAccounts: map[subscriberID]DeliveryFn{},
+		options:     map[subscriberID]SubscribeToTraceOptions{},
+		currentID:   1,
+	}
+}
+
+func (disp *TraceDispatcher) dispatch(accountIDs []tongo.AccountID, event []byte) {
+	disp.mu.RLock()
+	defer disp.mu.RUnlock()
+
+	// we don't want to deliver the same event twice to the same subscriber.
+	delivered := make(map[subscriberID]struct{}, len(disp.allAccounts))
+
+	for subscriberID, deliveryFn := range disp.allAccounts {
+		delivered[subscriberID] = struct{}{}
+		deliveryFn(event)
+	}
+	for _, account := range accountIDs {
+		subscribers := disp.accounts[account]
+		for subscriberID, deliveryFn := range subscribers {
+			if _, ok := delivered[subscriberID]; ok {
+				continue
+			}
+			delivered[subscriberID] = struct{}{}
+			deliveryFn(event)
+		}
+	}
+}
+
+func (disp *TraceDispatcher) RegisterSubscriber(fn DeliveryFn, options SubscribeToTraceOptions) CancelFn {
+	disp.mu.Lock()
+	defer disp.mu.Unlock()
+
+	id := disp.currentID
+	disp.currentID += 1
+	disp.options[id] = options
+
+	if options.AllAccounts {
+		disp.allAccounts[id] = fn
+		return func() { disp.unsubscribe(id) }
+	}
+
+	for _, account := range options.Accounts {
+		subscribers, ok := disp.accounts[account]
+		if !ok {
+			subscribers = map[subscriberID]DeliveryFn{id: fn}
+			disp.accounts[account] = subscribers
+		}
+		subscribers[id] = fn
+	}
+
+	return func() { disp.unsubscribe(id) }
+}
+
+func (disp *TraceDispatcher) unsubscribe(id subscriberID) {
+	disp.mu.Lock()
+	defer disp.mu.Unlock()
+
+	options, ok := disp.options[id]
+	if !ok {
+		return
+	}
+	delete(disp.options, id)
+	if options.AllAccounts {
+		delete(disp.allAccounts, id)
+		return
+	}
+	for _, account := range options.Accounts {
+		subscribers, ok := disp.accounts[account]
+		if !ok {
+			continue
+		}
+		delete(subscribers, id)
+		if len(subscribers) == 0 {
+			delete(disp.accounts, account)
+		}
+	}
+}

--- a/pkg/pusher/sources/tracer.go
+++ b/pkg/pusher/sources/tracer.go
@@ -1,0 +1,133 @@
+package sources
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/tonkeeper/opentonapi/pkg/core"
+	"github.com/tonkeeper/tongo"
+	"go.uber.org/zap"
+	"golang.org/x/exp/maps"
+)
+
+var (
+	traceNumber = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "trace_number",
+		Help: "Number of processed traces",
+	}, []string{"completeness"})
+)
+
+type SubscribeToTraceOptions struct {
+	AllAccounts bool
+	Accounts    []tongo.AccountID
+}
+
+type TraceSource interface {
+	SubscribeToTraces(ctx context.Context, deliveryFn DeliveryFn, opts SubscribeToTraceOptions) CancelFn
+}
+
+type storage interface {
+	GetTrace(ctx context.Context, hash tongo.Bits256) (*core.Trace, error)
+}
+
+type Tracer struct {
+	logger     *zap.Logger
+	storage    storage
+	dispatcher *TraceDispatcher
+	source     TransactionSource
+}
+
+func NewTracer(logger *zap.Logger, storage storage, source TransactionSource) *Tracer {
+	return &Tracer{
+		logger:     logger,
+		storage:    storage,
+		source:     source,
+		dispatcher: NewTraceDispatcher(logger),
+	}
+}
+
+var _ TraceSource = (*Tracer)(nil)
+
+func (t *Tracer) SubscribeToTraces(ctx context.Context, deliveryFn DeliveryFn, opts SubscribeToTraceOptions) CancelFn {
+	t.logger.Debug("subscribe to traces",
+		zap.Bool("all-accounts", opts.AllAccounts),
+		zap.Stringers("accounts", opts.Accounts))
+
+	return t.dispatcher.RegisterSubscriber(deliveryFn, opts)
+}
+
+func (t *Tracer) Run(ctx context.Context) {
+	num := 10 // todo: make configurable
+	txCh := make(chan TransactionEventData, num)
+	cancelFn := t.source.SubscribeToTransactions(ctx, func(eventData []byte) {
+		var tx TransactionEventData
+		if err := json.Unmarshal(eventData, &tx); err != nil {
+			t.logger.Error("json.Unmarshal() failed", zap.Error(err))
+			return
+		}
+		txCh <- tx
+	}, SubscribeToTransactionsOptions{AllAccounts: true})
+
+	defer cancelFn()
+
+	var wg sync.WaitGroup
+	wg.Add(num)
+
+	for i := 0; i < num; i++ {
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case txEvent := <-txCh:
+					var hash tongo.Bits256
+					if err := hash.FromHex(txEvent.TxHash); err != nil {
+						// this should never happen
+						t.logger.Error("hash.FromHex() failed", zap.Error(err))
+						continue
+					}
+					trace, err := t.storage.GetTrace(ctx, hash)
+					if err != nil {
+						continue
+					}
+					t.dispatch(trace)
+				}
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func (t *Tracer) dispatch(trace *core.Trace) {
+	if trace.InProgress() {
+		traceNumber.With(map[string]string{"completeness": "inProgress"}).Inc()
+		return
+	}
+	traceNumber.With(map[string]string{"completeness": "completed"}).Inc()
+
+	accounts := make(map[tongo.AccountID]struct{})
+	queue := []*core.Trace{trace}
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		accounts[current.Account] = struct{}{}
+		queue = append(queue, current.Children...)
+	}
+
+	accountIDs := maps.Keys(accounts)
+	eventData := &TraceEventData{
+		AccountIDs: accountIDs,
+		Hash:       trace.Hash.Hex(),
+	}
+	eventJSON, err := json.Marshal(eventData)
+	if err != nil {
+		t.logger.Error("json.Marshal() failed: %v", zap.Error(err))
+		return
+	}
+
+	t.dispatcher.dispatch(accountIDs, eventJSON)
+}

--- a/pkg/pusher/websocket/handler.go
+++ b/pkg/pusher/websocket/handler.go
@@ -32,7 +32,7 @@ type JsonRPCResponse struct {
 	Params  json.RawMessage `json:"params,omitempty"`
 }
 
-func Handler(logger *zap.Logger, txSource sources.TransactionSource, mempool sources.MemPoolSource) func(http.ResponseWriter, *http.Request, int, bool) error {
+func Handler(logger *zap.Logger, txSource sources.TransactionSource, traceSource sources.TraceSource, mempool sources.MemPoolSource) func(http.ResponseWriter, *http.Request, int, bool) error {
 	return func(w http.ResponseWriter, r *http.Request, connectionType int, allowTokenInQuery bool) error {
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
@@ -47,7 +47,7 @@ func Handler(logger *zap.Logger, txSource sources.TransactionSource, mempool sou
 		metrics.OpenWebsocketConnection(utils.TokenNameFromContext(r.Context()))
 		defer metrics.CloseWebsocketConnection(utils.TokenNameFromContext(r.Context()))
 
-		session := newSession(logger, txSource, mempool, conn)
+		session := newSession(logger, txSource, traceSource, mempool, conn)
 		requestCh := session.Run(ctx)
 		for {
 			_, msg, err := conn.ReadMessage()

--- a/pkg/pusher/websocket/session_test.go
+++ b/pkg/pusher/websocket/session_test.go
@@ -52,7 +52,7 @@ func Test_session_subscribeToTransactions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &session{
 				eventCh:           make(chan event, 10),
-				subscriptions:     map[tongo.AccountID]sources.CancelFn{},
+				txSubscriptions:   map[tongo.AccountID]sources.CancelFn{},
 				subscriptionLimit: tt.subscriptionLimit,
 				txSource: &mockTxSource{
 					OnSubscribeToTransactions: func(ctx context.Context, deliveryFn sources.DeliveryFn, opts sources.SubscribeToTransactionsOptions) sources.CancelFn {
@@ -64,7 +64,7 @@ func Test_session_subscribeToTransactions(t *testing.T) {
 			msg := s.subscribeToTransactions(context.Background(), tt.params)
 			require.Equal(t, tt.want, msg)
 			subs := make(map[tongo.AccountID]struct{})
-			for sub := range s.subscriptions {
+			for sub := range s.txSubscriptions {
 				subs[sub] = struct{}{}
 			}
 			require.Equal(t, tt.wantSubscriptions, subs)


### PR DESCRIPTION
This request adds the following methods to Streaming API:
1. new `subscribe_trace` method to websocket
2. new /sse/accounts/traces method 

Both methods notify subscribers about completed traces.

