### PR TITLE
Add WithTonApiKey function to client package

### DIFF
--- a/client/client_options.go
+++ b/client/client_options.go
@@ -1,0 +1,37 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+
+	ht "github.com/ogen-go/ogen/http"
+)
+
+type clientWithApiKey struct {
+	header string
+}
+
+func (c clientWithApiKey) Do(r *http.Request) (*http.Response, error) {
+	r.Header.Set("Authorization", c.header)
+	return http.DefaultClient.Do(r)
+}
+
+var _ ht.Client = &clientWithApiKey{}
+
+// WithTonApiKey configures client to use tonApiKey for authorization.
+// When working with tonapi.io, you should consider getting an API key at https://tonconsole.com/.
+//
+// Example:
+//
+// import (
+//
+//	tonapiClient "github.com/tonkeeper/opentonapi/client"
+//
+// )
+//
+//	func main() {
+//	   cli, _ := tonapiClient.NewClient("https://tonapi.io", tonapiClient.WithTonApiKey(tonapiKey))
+//	}
+func WithTonApiKey(tonApiKey string) ClientOption {
+	return WithClient(&clientWithApiKey{header: fmt.Sprintf("Bearer %s", tonApiKey)})
+}


### PR DESCRIPTION
  The idea is to use WithTonApiKey in the following way:

```go
  import (
     tonapiClient "github.com/tonkeeper/opentonapi/client"
  )

  func main() {
     cli, _ := tonapiClient.NewClient("https://tonapi.io", tonapiClient.WithTonApiKey(tonapiKey))
  }
```