### PR TITLE
Add api methods to request blockchain config

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -2811,6 +2811,19 @@
     ],
     "type": "object"
    },
+   "RawBlockchainConfig": {
+    "properties": {
+     "config": {
+      "additionalProperties": true,
+      "example": {},
+      "type": "object"
+     }
+    },
+    "required": [
+     "config"
+    ],
+    "type": "object"
+   },
    "Refund": {
     "properties": {
      "origin": {
@@ -4672,6 +4685,35 @@
     ]
    }
   },
+  "/v2/blockchain/blocks/{block_id}/config/raw": {
+   "get": {
+    "description": "Get raw blockchain config from a specific block, if present.",
+    "operationId": "getRawBlockchainConfigFromBlock",
+    "parameters": [
+     {
+      "$ref": "#/components/parameters/blockchainBlockIDParameter"
+     }
+    ],
+    "responses": {
+     "200": {
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/RawBlockchainConfig"
+        }
+       }
+      },
+      "description": "blockchain config"
+     },
+     "default": {
+      "$ref": "#/components/responses/Error"
+     }
+    },
+    "tags": [
+     "Blockchain"
+    ]
+   }
+  },
   "/v2/blockchain/blocks/{block_id}/transactions": {
    "get": {
     "description": "Get transactions from block",
@@ -4711,6 +4753,30 @@
        "application/json": {
         "schema": {
          "$ref": "#/components/schemas/BlockchainConfig"
+        }
+       }
+      },
+      "description": "blockchain config"
+     },
+     "default": {
+      "$ref": "#/components/responses/Error"
+     }
+    },
+    "tags": [
+     "Blockchain"
+    ]
+   }
+  },
+  "/v2/blockchain/config/raw": {
+   "get": {
+    "description": "Get raw blockchain config",
+    "operationId": "getRawBlockchainConfig",
+    "responses": {
+     "200": {
+      "content": {
+       "application/json": {
+        "schema": {
+         "$ref": "#/components/schemas/RawBlockchainConfig"
         }
        }
       },

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -45,6 +45,23 @@ paths:
                 $ref: '#/components/schemas/Transactions'
         'default':
           $ref: '#/components/responses/Error'
+  /v2/blockchain/blocks/{block_id}/config/raw:
+    get:
+      description: Get raw blockchain config from a specific block, if present.
+      operationId: getRawBlockchainConfigFromBlock
+      tags:
+        - Blockchain
+      parameters:
+        - $ref: '#/components/parameters/blockchainBlockIDParameter'
+      responses:
+        '200':
+          description: blockchain config
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RawBlockchainConfig'
+        'default':
+          $ref: '#/components/responses/Error'
   /v2/blockchain/transactions/{transaction_id}:
     get:
       description: Get transaction data
@@ -218,6 +235,21 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BlockchainConfig'
+        'default':
+          $ref: '#/components/responses/Error'
+  /v2/blockchain/config/raw:
+    get:
+      description: Get raw blockchain config
+      operationId: getRawBlockchainConfig
+      tags:
+        - Blockchain
+      responses:
+        '200':
+          description: blockchain config
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RawBlockchainConfig'
         'default':
           $ref: '#/components/responses/Error'
   /v2/blockchain/accounts/{account_id}/inspect:
@@ -3148,6 +3180,16 @@ components:
           example: [ ]
           items:
             $ref: '#/components/schemas/TvmStackRecord'
+    RawBlockchainConfig:
+      type: object
+      required:
+        - config
+      properties:
+        config:
+          type: object
+          additionalProperties: true
+          example: { }
+
     BlockchainConfig:
       type: object
       required:

--- a/client/oas_client_gen.go
+++ b/client/oas_client_gen.go
@@ -368,6 +368,18 @@ type Invoker interface {
 	//
 	// GET /v2/liteserver/get_state/{block_id}
 	GetRawBlockchainBlockState(ctx context.Context, params GetRawBlockchainBlockStateParams) (*GetRawBlockchainBlockStateOK, error)
+	// GetRawBlockchainConfig invokes getRawBlockchainConfig operation.
+	//
+	// Get raw blockchain config.
+	//
+	// GET /v2/blockchain/config/raw
+	GetRawBlockchainConfig(ctx context.Context) (*RawBlockchainConfig, error)
+	// GetRawBlockchainConfigFromBlock invokes getRawBlockchainConfigFromBlock operation.
+	//
+	// Get raw blockchain config from a specific block, if present.
+	//
+	// GET /v2/blockchain/blocks/{block_id}/config/raw
+	GetRawBlockchainConfigFromBlock(ctx context.Context, params GetRawBlockchainConfigFromBlockParams) (*RawBlockchainConfig, error)
 	// GetRawConfig invokes getRawConfig operation.
 	//
 	// Get raw config.
@@ -6630,6 +6642,169 @@ func (c *Client) sendGetRawBlockchainBlockState(ctx context.Context, params GetR
 
 	stage = "DecodeResponse"
 	result, err := decodeGetRawBlockchainBlockStateResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// GetRawBlockchainConfig invokes getRawBlockchainConfig operation.
+//
+// Get raw blockchain config.
+//
+// GET /v2/blockchain/config/raw
+func (c *Client) GetRawBlockchainConfig(ctx context.Context) (*RawBlockchainConfig, error) {
+	res, err := c.sendGetRawBlockchainConfig(ctx)
+	return res, err
+}
+
+func (c *Client) sendGetRawBlockchainConfig(ctx context.Context) (res *RawBlockchainConfig, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("getRawBlockchainConfig"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/v2/blockchain/config/raw"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "GetRawBlockchainConfig",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [1]string
+	pathParts[0] = "/v2/blockchain/config/raw"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "GET", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeGetRawBlockchainConfigResponse(resp)
+	if err != nil {
+		return res, errors.Wrap(err, "decode response")
+	}
+
+	return result, nil
+}
+
+// GetRawBlockchainConfigFromBlock invokes getRawBlockchainConfigFromBlock operation.
+//
+// Get raw blockchain config from a specific block, if present.
+//
+// GET /v2/blockchain/blocks/{block_id}/config/raw
+func (c *Client) GetRawBlockchainConfigFromBlock(ctx context.Context, params GetRawBlockchainConfigFromBlockParams) (*RawBlockchainConfig, error) {
+	res, err := c.sendGetRawBlockchainConfigFromBlock(ctx, params)
+	return res, err
+}
+
+func (c *Client) sendGetRawBlockchainConfigFromBlock(ctx context.Context, params GetRawBlockchainConfigFromBlockParams) (res *RawBlockchainConfig, err error) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("getRawBlockchainConfigFromBlock"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/v2/blockchain/blocks/{block_id}/config/raw"),
+	}
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		elapsedDuration := time.Since(startTime)
+		c.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	c.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	// Start a span for this request.
+	ctx, span := c.cfg.Tracer.Start(ctx, "GetRawBlockchainConfigFromBlock",
+		trace.WithAttributes(otelAttrs...),
+		clientSpanKind,
+	)
+	// Track stage for error reporting.
+	var stage string
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			c.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		span.End()
+	}()
+
+	stage = "BuildURL"
+	u := uri.Clone(c.requestURL(ctx))
+	var pathParts [3]string
+	pathParts[0] = "/v2/blockchain/blocks/"
+	{
+		// Encode "block_id" parameter.
+		e := uri.NewPathEncoder(uri.PathEncoderConfig{
+			Param:   "block_id",
+			Style:   uri.PathStyleSimple,
+			Explode: false,
+		})
+		if err := func() error {
+			return e.EncodeValue(conv.StringToString(params.BlockID))
+		}(); err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		encoded, err := e.Result()
+		if err != nil {
+			return res, errors.Wrap(err, "encode path")
+		}
+		pathParts[1] = encoded
+	}
+	pathParts[2] = "/config/raw"
+	uri.AddPathParts(u, pathParts[:]...)
+
+	stage = "EncodeRequest"
+	r, err := ht.NewRequest(ctx, "GET", u)
+	if err != nil {
+		return res, errors.Wrap(err, "create request")
+	}
+
+	stage = "SendRequest"
+	resp, err := c.cfg.Client.Do(r)
+	if err != nil {
+		return res, errors.Wrap(err, "do request")
+	}
+	defer resp.Body.Close()
+
+	stage = "DecodeResponse"
+	result, err := decodeGetRawBlockchainConfigFromBlockResponse(resp)
 	if err != nil {
 		return res, errors.Wrap(err, "decode response")
 	}

--- a/client/oas_json_gen.go
+++ b/client/oas_json_gen.go
@@ -18765,6 +18765,158 @@ func (s *Price) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *RawBlockchainConfig) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *RawBlockchainConfig) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("config")
+		s.Config.Encode(e)
+	}
+}
+
+var jsonFieldsNameOfRawBlockchainConfig = [1]string{
+	0: "config",
+}
+
+// Decode decodes RawBlockchainConfig from json.
+func (s *RawBlockchainConfig) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode RawBlockchainConfig to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "config":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.Config.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"config\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode RawBlockchainConfig")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfRawBlockchainConfig) {
+					name = jsonFieldsNameOfRawBlockchainConfig[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *RawBlockchainConfig) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *RawBlockchainConfig) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s RawBlockchainConfigConfig) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields implements json.Marshaler.
+func (s RawBlockchainConfigConfig) encodeFields(e *jx.Encoder) {
+	for k, elem := range s {
+		e.FieldStart(k)
+
+		if len(elem) != 0 {
+			e.Raw(elem)
+		}
+	}
+}
+
+// Decode decodes RawBlockchainConfigConfig from json.
+func (s *RawBlockchainConfigConfig) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode RawBlockchainConfigConfig to nil")
+	}
+	m := s.init()
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		var elem jx.Raw
+		if err := func() error {
+			v, err := d.RawAppend(nil)
+			elem = jx.Raw(v)
+			if err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return errors.Wrapf(err, "decode field %q", k)
+		}
+		m[string(k)] = elem
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode RawBlockchainConfigConfig")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s RawBlockchainConfigConfig) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *RawBlockchainConfigConfig) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *Refund) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)

--- a/client/oas_parameters_gen.go
+++ b/client/oas_parameters_gen.go
@@ -375,6 +375,12 @@ type GetRawBlockchainBlockStateParams struct {
 	BlockID string
 }
 
+// GetRawBlockchainConfigFromBlockParams is parameters of getRawBlockchainConfigFromBlock operation.
+type GetRawBlockchainConfigFromBlockParams struct {
+	// Block ID.
+	BlockID string
+}
+
 // GetRawConfigParams is parameters of getRawConfig operation.
 type GetRawConfigParams struct {
 	// Block ID: (workchain,shard,seqno,root_hash,file_hash).

--- a/client/oas_response_decoders_gen.go
+++ b/client/oas_response_decoders_gen.go
@@ -4662,6 +4662,172 @@ func decodeGetRawBlockchainBlockStateResponse(resp *http.Response) (res *GetRawB
 	return res, errors.Wrap(defRes, "error")
 }
 
+func decodeGetRawBlockchainConfigResponse(resp *http.Response) (res *RawBlockchainConfig, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response RawBlockchainConfig
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	// Convenient error response.
+	defRes, err := func() (res *ErrorStatusCode, err error) {
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &ErrorStatusCode{
+				StatusCode: resp.StatusCode,
+				Response:   response,
+			}, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}()
+	if err != nil {
+		return res, errors.Wrapf(err, "default (code %d)", resp.StatusCode)
+	}
+	return res, errors.Wrap(defRes, "error")
+}
+
+func decodeGetRawBlockchainConfigFromBlockResponse(resp *http.Response) (res *RawBlockchainConfig, _ error) {
+	switch resp.StatusCode {
+	case 200:
+		// Code 200.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response RawBlockchainConfig
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}
+	// Convenient error response.
+	defRes, err := func() (res *ErrorStatusCode, err error) {
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response Error
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &ErrorStatusCode{
+				StatusCode: resp.StatusCode,
+				Response:   response,
+			}, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	}()
+	if err != nil {
+		return res, errors.Wrapf(err, "default (code %d)", resp.StatusCode)
+	}
+	return res, errors.Wrap(defRes, "error")
+}
+
 func decodeGetRawConfigResponse(resp *http.Response) (res *GetRawConfigOK, _ error) {
 	switch resp.StatusCode {
 	case 200:

--- a/client/oas_schemas_gen.go
+++ b/client/oas_schemas_gen.go
@@ -8370,6 +8370,32 @@ func (s *Price) SetTokenName(val string) {
 	s.TokenName = val
 }
 
+// Ref: #/components/schemas/RawBlockchainConfig
+type RawBlockchainConfig struct {
+	Config RawBlockchainConfigConfig `json:"config"`
+}
+
+// GetConfig returns the value of Config.
+func (s *RawBlockchainConfig) GetConfig() RawBlockchainConfigConfig {
+	return s.Config
+}
+
+// SetConfig sets the value of Config.
+func (s *RawBlockchainConfig) SetConfig(val RawBlockchainConfigConfig) {
+	s.Config = val
+}
+
+type RawBlockchainConfigConfig map[string]jx.Raw
+
+func (s *RawBlockchainConfigConfig) init() RawBlockchainConfigConfig {
+	m := *s
+	if m == nil {
+		m = map[string]jx.Raw{}
+		*s = m
+	}
+	return m
+}
+
 // Ref: #/components/schemas/Refund
 type Refund struct {
 	Type   RefundType `json:"type"`

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/sourcegraph/conc v0.3.0
 	github.com/stretchr/testify v1.8.4
 	github.com/tonkeeper/scam_backoffice_rules v0.0.0-20231009153936-f766159e8ddb
-	github.com/tonkeeper/tongo v1.3.3-0.20231009134841-2a04a2067cea
+	github.com/tonkeeper/tongo v1.3.4-0.20231026105625-8a256dbf9884
 	go.opentelemetry.io/otel v1.19.0
 	go.opentelemetry.io/otel/metric v1.19.0
 	go.opentelemetry.io/otel/trace v1.19.0

--- a/go.sum
+++ b/go.sum
@@ -262,8 +262,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tonkeeper/scam_backoffice_rules v0.0.0-20231009153936-f766159e8ddb h1:2LTKp4o9QhUinV1lVme5P2nDS/6GyGKuULlkkdFwbVQ=
 github.com/tonkeeper/scam_backoffice_rules v0.0.0-20231009153936-f766159e8ddb/go.mod h1:Yz73oGYjlqIFq6s7h5gFy6TouLVK9ortBxcXDiU38J4=
-github.com/tonkeeper/tongo v1.3.3-0.20231009134841-2a04a2067cea h1:+cBmJqBYluwRJe+XlVxqUMAjwr1djv8zeHUNz7MXi2w=
-github.com/tonkeeper/tongo v1.3.3-0.20231009134841-2a04a2067cea/go.mod h1:LdOBjpUz6vLp1EdX3E0XLNks9YI5XMSqaQahfOMrBEY=
+github.com/tonkeeper/tongo v1.3.4-0.20231026105625-8a256dbf9884 h1:GwE/wrb415Qy/zo1kYbvKfoMIJDc7K9E+0v8C6RoXao=
+github.com/tonkeeper/tongo v1.3.4-0.20231026105625-8a256dbf9884/go.mod h1:LdOBjpUz6vLp1EdX3E0XLNks9YI5XMSqaQahfOMrBEY=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=

--- a/internal/g/camel_snake.go
+++ b/internal/g/camel_snake.go
@@ -13,7 +13,7 @@ func CamelToSnake(s string) string {
 	b := new(strings.Builder)
 	b.Grow(len(s) + 5)
 	for i, c := range s {
-		if ('a' <= c && c <= 'z') || ('0' <= c && c <= '9') || c == '_' { //todo: not skip lower case but replase upper case
+		if ('a' <= c && c <= 'z') || ('0' <= c && c <= '9') || c == '_' || c == '-' || c == ':' { //todo: not skip lower case but replace upper case
 			b.WriteRune(c)
 			continue
 		}

--- a/pkg/api/blockchain_handlers_test.go
+++ b/pkg/api/blockchain_handlers_test.go
@@ -1,0 +1,107 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tonkeeper/opentonapi/pkg/litestorage"
+	"github.com/tonkeeper/opentonapi/pkg/oas"
+	"github.com/tonkeeper/tongo/config"
+	"go.uber.org/zap"
+)
+
+func TestHandler_GetRawBlockchainConfig(t *testing.T) {
+	logger := zap.L()
+	liteStorage, err := litestorage.NewLiteStorage(logger)
+	require.Nil(t, err)
+	h, err := NewHandler(logger, WithStorage(liteStorage), WithExecutor(liteStorage))
+	require.Nil(t, err)
+	cfg, err := h.GetRawBlockchainConfig(context.Background())
+	require.Nil(t, err)
+	require.True(t, len(cfg.Config) > 10)
+}
+
+func TestHandler_GetRawBlockchainConfigFromBlock(t *testing.T) {
+	var servers []config.LiteServer
+	if env, ok := os.LookupEnv("LITE_SERVERS"); ok {
+		var err error
+		servers, err = config.ParseLiteServersEnvVar(env)
+		require.Nil(t, err)
+	}
+	tests := []struct {
+		name              string
+		params            oas.GetRawBlockchainConfigFromBlockParams
+		wantKeys          map[string]struct{}
+		wantErr           string
+		wantErrStatusCode int
+	}{
+		{
+			name: "all good",
+			params: oas.GetRawBlockchainConfigFromBlockParams{
+				BlockID: "(-1,8000000000000000,4645003)",
+			},
+			wantKeys: map[string]struct{}{
+				"config_param0":  {},
+				"config_param1":  {},
+				"config_param10": {},
+				"config_param11": {},
+				"config_param12": {},
+				"config_param14": {},
+				"config_param15": {},
+				"config_param16": {},
+				"config_param17": {},
+				"config_param18": {},
+				"config_param2":  {},
+				"config_param20": {},
+				"config_param21": {},
+				"config_param22": {},
+				"config_param23": {},
+				"config_param24": {},
+				"config_param25": {},
+				"config_param28": {},
+				"config_param29": {},
+				"config_param31": {},
+				"config_param32": {},
+				"config_param34": {},
+				"config_param4":  {},
+				"config_param7":  {},
+				"config_param8":  {},
+				"config_param9":  {},
+			},
+		},
+		{
+			name: "not a key block",
+			params: oas.GetRawBlockchainConfigFromBlockParams{
+				BlockID: "(-1,8000000000000000,4645004)",
+			},
+			wantErr:           "block must be a key block",
+			wantErrStatusCode: 404,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := zap.L()
+			liteStorage, err := litestorage.NewLiteStorage(logger, litestorage.WithLiteServers(servers))
+			require.Nil(t, err)
+			h, err := NewHandler(logger, WithStorage(liteStorage), WithExecutor(liteStorage))
+			require.Nil(t, err)
+			cfg, err := h.GetRawBlockchainConfigFromBlock(context.Background(), tt.params)
+			if len(tt.wantErr) > 0 {
+				var oasErr *oas.ErrorStatusCode
+				errors.As(err, &oasErr)
+				require.Equal(t, oasErr.StatusCode, tt.wantErrStatusCode)
+				require.Equal(t, oasErr.Response.Error, tt.wantErr)
+				return
+			}
+			require.Nil(t, err)
+			keys := make(map[string]struct{})
+			for key := range cfg.Config {
+				keys[key] = struct{}{}
+			}
+			require.Equal(t, tt.wantKeys, keys)
+		})
+	}
+}

--- a/pkg/api/interfaces.go
+++ b/pkg/api/interfaces.go
@@ -6,13 +6,13 @@ import (
 	"sync"
 
 	rules "github.com/tonkeeper/scam_backoffice_rules"
-	"github.com/tonkeeper/tongo/boc"
-
 	"github.com/tonkeeper/tongo"
 	"github.com/tonkeeper/tongo/abi"
+	"github.com/tonkeeper/tongo/boc"
 	"github.com/tonkeeper/tongo/liteclient"
 	"github.com/tonkeeper/tongo/tep64"
 	"github.com/tonkeeper/tongo/tlb"
+	"github.com/tonkeeper/tongo/ton"
 
 	"github.com/tonkeeper/opentonapi/pkg/addressbook"
 	"github.com/tonkeeper/opentonapi/pkg/cache"
@@ -81,6 +81,7 @@ type storage interface {
 	GetJettonMasters(ctx context.Context, limit, offset int) ([]core.JettonMaster, error)
 
 	GetLastConfig(ctx context.Context) (tlb.ConfigParams, error)
+	GetConfigFromBlock(ctx context.Context, id ton.BlockID) (tlb.ConfigParams, error)
 
 	GetSeqno(ctx context.Context, account tongo.AccountID) (uint32, error)
 

--- a/pkg/core/errors.go
+++ b/pkg/core/errors.go
@@ -4,3 +4,4 @@ import "errors"
 
 var ErrEntityNotFound = errors.New("entity not found")
 var ErrTooManyEntities = errors.New("too many entities")
+var ErrNotKeyBlock = errors.New("block must be a key block")

--- a/pkg/core/testdata/convert-tx-1.json
+++ b/pkg/core/testdata/convert-tx-1.json
@@ -66,7 +66,7 @@
    "PrevTransHash": "ec81d97a4a66e762122b44a822dfce0e51f7761cdef1841dda66ae30ce961496",
    "PrevTransLt": 37362731000003,
    "StateHashUpdate": {
-     "Magic": 0,
+     "Magic": "0x72",
      "OldHash": "11f4cd47b373711e7eb92a258acddd2a58773939b9140ccd5dff4d9ee9688eee",
      "NewHash": "53ab652177004a4805d85e1d1ca1f6d7c97a946a3def3e33218be95b487df027"
    },

--- a/pkg/litestorage/config.go
+++ b/pkg/litestorage/config.go
@@ -3,9 +3,23 @@ package litestorage
 import (
 	"context"
 
+	"github.com/tonkeeper/opentonapi/pkg/core"
 	"github.com/tonkeeper/tongo/tlb"
+	"github.com/tonkeeper/tongo/ton"
 )
 
 func (c *LiteStorage) GetLastConfig(ctx context.Context) (tlb.ConfigParams, error) {
 	return c.client.GetConfigAll(ctx, 0)
+}
+
+func (c *LiteStorage) GetConfigFromBlock(ctx context.Context, id ton.BlockID) (tlb.ConfigParams, error) {
+	extID, info, err := c.client.LookupBlock(ctx, id, 1, nil, nil)
+	if err != nil {
+		return tlb.ConfigParams{}, err
+	}
+	if !info.KeyBlock {
+		return tlb.ConfigParams{}, core.ErrNotKeyBlock
+	}
+	cli := c.client.WithBlock(extID)
+	return cli.GetConfigAll(ctx, 0)
 }

--- a/pkg/oas/oas_handlers_gen.go
+++ b/pkg/oas/oas_handlers_gen.go
@@ -6813,6 +6813,221 @@ func (s *Server) handleGetRawBlockchainBlockStateRequest(args [1]string, argsEsc
 	}
 }
 
+// handleGetRawBlockchainConfigRequest handles getRawBlockchainConfig operation.
+//
+// Get raw blockchain config.
+//
+// GET /v2/blockchain/config/raw
+func (s *Server) handleGetRawBlockchainConfigRequest(args [0]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("getRawBlockchainConfig"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/v2/blockchain/config/raw"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "GetRawBlockchainConfig",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err error
+	)
+
+	var response *RawBlockchainConfig
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "GetRawBlockchainConfig",
+			OperationSummary: "",
+			OperationID:      "getRawBlockchainConfig",
+			Body:             nil,
+			Params:           middleware.Parameters{},
+			Raw:              r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = struct{}
+			Response = *RawBlockchainConfig
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			nil,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.GetRawBlockchainConfig(ctx)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.GetRawBlockchainConfig(ctx)
+	}
+	if err != nil {
+		if errRes, ok := errors.Into[*ErrorStatusCode](err); ok {
+			if err := encodeErrorResponse(errRes, w, span); err != nil {
+				recordError("Internal", err)
+			}
+			return
+		}
+		if errors.Is(err, ht.ErrNotImplemented) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+		if err := encodeErrorResponse(s.h.NewError(ctx, err), w, span); err != nil {
+			recordError("Internal", err)
+		}
+		return
+	}
+
+	if err := encodeGetRawBlockchainConfigResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
+// handleGetRawBlockchainConfigFromBlockRequest handles getRawBlockchainConfigFromBlock operation.
+//
+// Get raw blockchain config from a specific block, if present.
+//
+// GET /v2/blockchain/blocks/{block_id}/config/raw
+func (s *Server) handleGetRawBlockchainConfigFromBlockRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
+	otelAttrs := []attribute.KeyValue{
+		otelogen.OperationID("getRawBlockchainConfigFromBlock"),
+		semconv.HTTPMethodKey.String("GET"),
+		semconv.HTTPRouteKey.String("/v2/blockchain/blocks/{block_id}/config/raw"),
+	}
+
+	// Start a span for this request.
+	ctx, span := s.cfg.Tracer.Start(r.Context(), "GetRawBlockchainConfigFromBlock",
+		trace.WithAttributes(otelAttrs...),
+		serverSpanKind,
+	)
+	defer span.End()
+
+	// Run stopwatch.
+	startTime := time.Now()
+	defer func() {
+		elapsedDuration := time.Since(startTime)
+		// Use floating point division here for higher precision (instead of Millisecond method).
+		s.duration.Record(ctx, float64(float64(elapsedDuration)/float64(time.Millisecond)), metric.WithAttributes(otelAttrs...))
+	}()
+
+	// Increment request counter.
+	s.requests.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+
+	var (
+		recordError = func(stage string, err error) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, stage)
+			s.errors.Add(ctx, 1, metric.WithAttributes(otelAttrs...))
+		}
+		err          error
+		opErrContext = ogenerrors.OperationContext{
+			Name: "GetRawBlockchainConfigFromBlock",
+			ID:   "getRawBlockchainConfigFromBlock",
+		}
+	)
+	params, err := decodeGetRawBlockchainConfigFromBlockParams(args, argsEscaped, r)
+	if err != nil {
+		err = &ogenerrors.DecodeParamsError{
+			OperationContext: opErrContext,
+			Err:              err,
+		}
+		recordError("DecodeParams", err)
+		s.cfg.ErrorHandler(ctx, w, r, err)
+		return
+	}
+
+	var response *RawBlockchainConfig
+	if m := s.cfg.Middleware; m != nil {
+		mreq := middleware.Request{
+			Context:          ctx,
+			OperationName:    "GetRawBlockchainConfigFromBlock",
+			OperationSummary: "",
+			OperationID:      "getRawBlockchainConfigFromBlock",
+			Body:             nil,
+			Params: middleware.Parameters{
+				{
+					Name: "block_id",
+					In:   "path",
+				}: params.BlockID,
+			},
+			Raw: r,
+		}
+
+		type (
+			Request  = struct{}
+			Params   = GetRawBlockchainConfigFromBlockParams
+			Response = *RawBlockchainConfig
+		)
+		response, err = middleware.HookMiddleware[
+			Request,
+			Params,
+			Response,
+		](
+			m,
+			mreq,
+			unpackGetRawBlockchainConfigFromBlockParams,
+			func(ctx context.Context, request Request, params Params) (response Response, err error) {
+				response, err = s.h.GetRawBlockchainConfigFromBlock(ctx, params)
+				return response, err
+			},
+		)
+	} else {
+		response, err = s.h.GetRawBlockchainConfigFromBlock(ctx, params)
+	}
+	if err != nil {
+		if errRes, ok := errors.Into[*ErrorStatusCode](err); ok {
+			if err := encodeErrorResponse(errRes, w, span); err != nil {
+				recordError("Internal", err)
+			}
+			return
+		}
+		if errors.Is(err, ht.ErrNotImplemented) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+			return
+		}
+		if err := encodeErrorResponse(s.h.NewError(ctx, err), w, span); err != nil {
+			recordError("Internal", err)
+		}
+		return
+	}
+
+	if err := encodeGetRawBlockchainConfigFromBlockResponse(response, w, span); err != nil {
+		recordError("EncodeResponse", err)
+		if !errors.Is(err, ht.ErrInternalServerErrorResponse) {
+			s.cfg.ErrorHandler(ctx, w, r, err)
+		}
+		return
+	}
+}
+
 // handleGetRawConfigRequest handles getRawConfig operation.
 //
 // Get raw config.

--- a/pkg/oas/oas_json_gen.go
+++ b/pkg/oas/oas_json_gen.go
@@ -18765,6 +18765,158 @@ func (s *Price) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *RawBlockchainConfig) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *RawBlockchainConfig) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("config")
+		s.Config.Encode(e)
+	}
+}
+
+var jsonFieldsNameOfRawBlockchainConfig = [1]string{
+	0: "config",
+}
+
+// Decode decodes RawBlockchainConfig from json.
+func (s *RawBlockchainConfig) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode RawBlockchainConfig to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "config":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.Config.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"config\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode RawBlockchainConfig")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000001,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfRawBlockchainConfig) {
+					name = jsonFieldsNameOfRawBlockchainConfig[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *RawBlockchainConfig) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *RawBlockchainConfig) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s RawBlockchainConfigConfig) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields implements json.Marshaler.
+func (s RawBlockchainConfigConfig) encodeFields(e *jx.Encoder) {
+	for k, elem := range s {
+		e.FieldStart(k)
+
+		if len(elem) != 0 {
+			e.Raw(elem)
+		}
+	}
+}
+
+// Decode decodes RawBlockchainConfigConfig from json.
+func (s *RawBlockchainConfigConfig) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode RawBlockchainConfigConfig to nil")
+	}
+	m := s.init()
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		var elem jx.Raw
+		if err := func() error {
+			v, err := d.RawAppend(nil)
+			elem = jx.Raw(v)
+			if err != nil {
+				return err
+			}
+			return nil
+		}(); err != nil {
+			return errors.Wrapf(err, "decode field %q", k)
+		}
+		m[string(k)] = elem
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode RawBlockchainConfigConfig")
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s RawBlockchainConfigConfig) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *RawBlockchainConfigConfig) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *Refund) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)

--- a/pkg/oas/oas_parameters_gen.go
+++ b/pkg/oas/oas_parameters_gen.go
@@ -6702,6 +6702,72 @@ func decodeGetRawBlockchainBlockStateParams(args [1]string, argsEscaped bool, r 
 	return params, nil
 }
 
+// GetRawBlockchainConfigFromBlockParams is parameters of getRawBlockchainConfigFromBlock operation.
+type GetRawBlockchainConfigFromBlockParams struct {
+	// Block ID.
+	BlockID string
+}
+
+func unpackGetRawBlockchainConfigFromBlockParams(packed middleware.Parameters) (params GetRawBlockchainConfigFromBlockParams) {
+	{
+		key := middleware.ParameterKey{
+			Name: "block_id",
+			In:   "path",
+		}
+		params.BlockID = packed[key].(string)
+	}
+	return params
+}
+
+func decodeGetRawBlockchainConfigFromBlockParams(args [1]string, argsEscaped bool, r *http.Request) (params GetRawBlockchainConfigFromBlockParams, _ error) {
+	// Decode path: block_id.
+	if err := func() error {
+		param := args[0]
+		if argsEscaped {
+			unescaped, err := url.PathUnescape(args[0])
+			if err != nil {
+				return errors.Wrap(err, "unescape path")
+			}
+			param = unescaped
+		}
+		if len(param) > 0 {
+			d := uri.NewPathDecoder(uri.PathDecoderConfig{
+				Param:   "block_id",
+				Value:   param,
+				Style:   uri.PathStyleSimple,
+				Explode: false,
+			})
+
+			if err := func() error {
+				val, err := d.DecodeValue()
+				if err != nil {
+					return err
+				}
+
+				c, err := conv.ToString(val)
+				if err != nil {
+					return err
+				}
+
+				params.BlockID = c
+				return nil
+			}(); err != nil {
+				return err
+			}
+		} else {
+			return validate.ErrFieldRequired
+		}
+		return nil
+	}(); err != nil {
+		return params, &ogenerrors.DecodeParamError{
+			Name: "block_id",
+			In:   "path",
+			Err:  err,
+		}
+	}
+	return params, nil
+}
+
 // GetRawConfigParams is parameters of getRawConfig operation.
 type GetRawConfigParams struct {
 	// Block ID: (workchain,shard,seqno,root_hash,file_hash).

--- a/pkg/oas/oas_response_encoders_gen.go
+++ b/pkg/oas/oas_response_encoders_gen.go
@@ -797,6 +797,34 @@ func encodeGetRawBlockchainBlockStateResponse(response *GetRawBlockchainBlockSta
 	return nil
 }
 
+func encodeGetRawBlockchainConfigResponse(response *RawBlockchainConfig, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := jx.GetEncoder()
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
+func encodeGetRawBlockchainConfigFromBlockResponse(response *RawBlockchainConfig, w http.ResponseWriter, span trace.Span) error {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(200)
+	span.SetStatus(codes.Ok, http.StatusText(200))
+
+	e := jx.GetEncoder()
+	response.Encode(e)
+	if _, err := e.WriteTo(w); err != nil {
+		return errors.Wrap(err, "write")
+	}
+
+	return nil
+}
+
 func encodeGetRawConfigResponse(response *GetRawConfigOK, w http.ResponseWriter, span trace.Span) error {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(200)

--- a/pkg/oas/oas_router_gen.go
+++ b/pkg/oas/oas_router_gen.go
@@ -656,25 +656,57 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						return
 					}
 					switch elem[0] {
-					case '/': // Prefix: "/transactions"
-						if l := len("/transactions"); len(elem) >= l && elem[0:l] == "/transactions" {
+					case '/': // Prefix: "/"
+						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
 							break
 						}
 
 						if len(elem) == 0 {
-							// Leaf node.
-							switch r.Method {
-							case "GET":
-								s.handleGetBlockchainBlockTransactionsRequest([1]string{
-									args[0],
-								}, elemIsEscaped, w, r)
-							default:
-								s.notAllowed(w, r, "GET")
+							break
+						}
+						switch elem[0] {
+						case 'c': // Prefix: "config/raw"
+							if l := len("config/raw"); len(elem) >= l && elem[0:l] == "config/raw" {
+								elem = elem[l:]
+							} else {
+								break
 							}
 
-							return
+							if len(elem) == 0 {
+								// Leaf node.
+								switch r.Method {
+								case "GET":
+									s.handleGetRawBlockchainConfigFromBlockRequest([1]string{
+										args[0],
+									}, elemIsEscaped, w, r)
+								default:
+									s.notAllowed(w, r, "GET")
+								}
+
+								return
+							}
+						case 't': // Prefix: "transactions"
+							if l := len("transactions"); len(elem) >= l && elem[0:l] == "transactions" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							if len(elem) == 0 {
+								// Leaf node.
+								switch r.Method {
+								case "GET":
+									s.handleGetBlockchainBlockTransactionsRequest([1]string{
+										args[0],
+									}, elemIsEscaped, w, r)
+								default:
+									s.notAllowed(w, r, "GET")
+								}
+
+								return
+							}
 						}
 					}
 				case 'c': // Prefix: "config"
@@ -685,7 +717,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					}
 
 					if len(elem) == 0 {
-						// Leaf node.
 						switch r.Method {
 						case "GET":
 							s.handleGetBlockchainConfigRequest([0]string{}, elemIsEscaped, w, r)
@@ -694,6 +725,26 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						}
 
 						return
+					}
+					switch elem[0] {
+					case '/': // Prefix: "/raw"
+						if l := len("/raw"); len(elem) >= l && elem[0:l] == "/raw" {
+							elem = elem[l:]
+						} else {
+							break
+						}
+
+						if len(elem) == 0 {
+							// Leaf node.
+							switch r.Method {
+							case "GET":
+								s.handleGetRawBlockchainConfigRequest([0]string{}, elemIsEscaped, w, r)
+							default:
+								s.notAllowed(w, r, "GET")
+							}
+
+							return
+						}
 					}
 				case 'm': // Prefix: "m"
 					if l := len("m"); len(elem) >= l && elem[0:l] == "m" {
@@ -2841,26 +2892,60 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 						}
 					}
 					switch elem[0] {
-					case '/': // Prefix: "/transactions"
-						if l := len("/transactions"); len(elem) >= l && elem[0:l] == "/transactions" {
+					case '/': // Prefix: "/"
+						if l := len("/"); len(elem) >= l && elem[0:l] == "/" {
 							elem = elem[l:]
 						} else {
 							break
 						}
 
 						if len(elem) == 0 {
-							switch method {
-							case "GET":
-								// Leaf: GetBlockchainBlockTransactions
-								r.name = "GetBlockchainBlockTransactions"
-								r.summary = ""
-								r.operationID = "getBlockchainBlockTransactions"
-								r.pathPattern = "/v2/blockchain/blocks/{block_id}/transactions"
-								r.args = args
-								r.count = 1
-								return r, true
-							default:
-								return
+							break
+						}
+						switch elem[0] {
+						case 'c': // Prefix: "config/raw"
+							if l := len("config/raw"); len(elem) >= l && elem[0:l] == "config/raw" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							if len(elem) == 0 {
+								switch method {
+								case "GET":
+									// Leaf: GetRawBlockchainConfigFromBlock
+									r.name = "GetRawBlockchainConfigFromBlock"
+									r.summary = ""
+									r.operationID = "getRawBlockchainConfigFromBlock"
+									r.pathPattern = "/v2/blockchain/blocks/{block_id}/config/raw"
+									r.args = args
+									r.count = 1
+									return r, true
+								default:
+									return
+								}
+							}
+						case 't': // Prefix: "transactions"
+							if l := len("transactions"); len(elem) >= l && elem[0:l] == "transactions" {
+								elem = elem[l:]
+							} else {
+								break
+							}
+
+							if len(elem) == 0 {
+								switch method {
+								case "GET":
+									// Leaf: GetBlockchainBlockTransactions
+									r.name = "GetBlockchainBlockTransactions"
+									r.summary = ""
+									r.operationID = "getBlockchainBlockTransactions"
+									r.pathPattern = "/v2/blockchain/blocks/{block_id}/transactions"
+									r.args = args
+									r.count = 1
+									return r, true
+								default:
+									return
+								}
 							}
 						}
 					}
@@ -2874,7 +2959,6 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 					if len(elem) == 0 {
 						switch method {
 						case "GET":
-							// Leaf: GetBlockchainConfig
 							r.name = "GetBlockchainConfig"
 							r.summary = ""
 							r.operationID = "getBlockchainConfig"
@@ -2884,6 +2968,30 @@ func (s *Server) FindPath(method string, u *url.URL) (r Route, _ bool) {
 							return r, true
 						default:
 							return
+						}
+					}
+					switch elem[0] {
+					case '/': // Prefix: "/raw"
+						if l := len("/raw"); len(elem) >= l && elem[0:l] == "/raw" {
+							elem = elem[l:]
+						} else {
+							break
+						}
+
+						if len(elem) == 0 {
+							switch method {
+							case "GET":
+								// Leaf: GetRawBlockchainConfig
+								r.name = "GetRawBlockchainConfig"
+								r.summary = ""
+								r.operationID = "getRawBlockchainConfig"
+								r.pathPattern = "/v2/blockchain/config/raw"
+								r.args = args
+								r.count = 0
+								return r, true
+							default:
+								return
+							}
 						}
 					}
 				case 'm': // Prefix: "m"

--- a/pkg/oas/oas_schemas_gen.go
+++ b/pkg/oas/oas_schemas_gen.go
@@ -8370,6 +8370,32 @@ func (s *Price) SetTokenName(val string) {
 	s.TokenName = val
 }
 
+// Ref: #/components/schemas/RawBlockchainConfig
+type RawBlockchainConfig struct {
+	Config RawBlockchainConfigConfig `json:"config"`
+}
+
+// GetConfig returns the value of Config.
+func (s *RawBlockchainConfig) GetConfig() RawBlockchainConfigConfig {
+	return s.Config
+}
+
+// SetConfig sets the value of Config.
+func (s *RawBlockchainConfig) SetConfig(val RawBlockchainConfigConfig) {
+	s.Config = val
+}
+
+type RawBlockchainConfigConfig map[string]jx.Raw
+
+func (s *RawBlockchainConfigConfig) init() RawBlockchainConfigConfig {
+	m := *s
+	if m == nil {
+		m = map[string]jx.Raw{}
+		*s = m
+	}
+	return m
+}
+
 // Ref: #/components/schemas/Refund
 type Refund struct {
 	Type   RefundType `json:"type"`

--- a/pkg/oas/oas_server_gen.go
+++ b/pkg/oas/oas_server_gen.go
@@ -353,6 +353,18 @@ type Handler interface {
 	//
 	// GET /v2/liteserver/get_state/{block_id}
 	GetRawBlockchainBlockState(ctx context.Context, params GetRawBlockchainBlockStateParams) (*GetRawBlockchainBlockStateOK, error)
+	// GetRawBlockchainConfig implements getRawBlockchainConfig operation.
+	//
+	// Get raw blockchain config.
+	//
+	// GET /v2/blockchain/config/raw
+	GetRawBlockchainConfig(ctx context.Context) (*RawBlockchainConfig, error)
+	// GetRawBlockchainConfigFromBlock implements getRawBlockchainConfigFromBlock operation.
+	//
+	// Get raw blockchain config from a specific block, if present.
+	//
+	// GET /v2/blockchain/blocks/{block_id}/config/raw
+	GetRawBlockchainConfigFromBlock(ctx context.Context, params GetRawBlockchainConfigFromBlockParams) (*RawBlockchainConfig, error)
 	// GetRawConfig implements getRawConfig operation.
 	//
 	// Get raw config.

--- a/pkg/oas/oas_unimplemented_gen.go
+++ b/pkg/oas/oas_unimplemented_gen.go
@@ -526,6 +526,24 @@ func (UnimplementedHandler) GetRawBlockchainBlockState(ctx context.Context, para
 	return r, ht.ErrNotImplemented
 }
 
+// GetRawBlockchainConfig implements getRawBlockchainConfig operation.
+//
+// Get raw blockchain config.
+//
+// GET /v2/blockchain/config/raw
+func (UnimplementedHandler) GetRawBlockchainConfig(ctx context.Context) (r *RawBlockchainConfig, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
+// GetRawBlockchainConfigFromBlock implements getRawBlockchainConfigFromBlock operation.
+//
+// Get raw blockchain config from a specific block, if present.
+//
+// GET /v2/blockchain/blocks/{block_id}/config/raw
+func (UnimplementedHandler) GetRawBlockchainConfigFromBlock(ctx context.Context, params GetRawBlockchainConfigFromBlockParams) (r *RawBlockchainConfig, _ error) {
+	return r, ht.ErrNotImplemented
+}
+
 // GetRawConfig implements getRawConfig operation.
 //
 // Get raw config.


### PR DESCRIPTION
   This PR adds two API methods:
   1. "/v2/blockchain/blocks/{block_id}/config/raw" returns a config stored in a particular block
   2. "/v2/blockchain/config/raw" returns the latest config