### PR TITLE
Streaming API: subscribe to account tx with operations

### DIFF
--- a/pkg/pusher/sources/blockchain_source.go
+++ b/pkg/pusher/sources/blockchain_source.go
@@ -3,8 +3,11 @@ package sources
 import (
 	"context"
 
+	"github.com/tonkeeper/opentonapi/internal/g"
 	"github.com/tonkeeper/opentonapi/pkg/blockchain/indexer"
 	"github.com/tonkeeper/tongo"
+	"github.com/tonkeeper/tongo/abi"
+	"github.com/tonkeeper/tongo/boc"
 	"github.com/tonkeeper/tongo/config"
 	"github.com/tonkeeper/tongo/liteapi"
 	"go.uber.org/zap"
@@ -12,9 +15,14 @@ import (
 
 // BlockchainSource notifies about transactions in the TON blockchain.
 type BlockchainSource struct {
-	dispatcher *TransactionDispatcher
+	dispatcher txDispatcher
 	client     *liteapi.Client
 	logger     *zap.Logger
+}
+
+type txDispatcher interface {
+	RegisterSubscriber(fn DeliveryFn, options SubscribeToTransactionsOptions) CancelFn
+	Run(ctx context.Context) chan TransactionEvent
 }
 
 func NewBlockchainSource(logger *zap.Logger, servers []config.LiteServer) (*BlockchainSource, error) {
@@ -41,9 +49,29 @@ var _ TransactionSource = (*BlockchainSource)(nil)
 func (b *BlockchainSource) SubscribeToTransactions(ctx context.Context, deliverFn DeliveryFn, opts SubscribeToTransactionsOptions) CancelFn {
 	b.logger.Debug("subscribe to transactions",
 		zap.Bool("all-accounts", opts.AllAccounts),
-		zap.Stringers("accounts", opts.Accounts))
+		zap.Bool("all-operations", opts.AllOperations),
+		zap.Stringers("accounts", opts.Accounts),
+		zap.Strings("operations", opts.Operations))
 
 	return b.dispatcher.RegisterSubscriber(deliverFn, opts)
+}
+
+func msgOpCodeAndName(cell *boc.Cell) (opCode *uint32, opName *abi.MsgOpName) {
+	if cell.BitsAvailableForRead() < 32 {
+		return nil, nil
+	}
+	opcode, err := cell.ReadUint(32)
+	if err != nil {
+		return nil, nil
+	}
+	msgOpCode := g.Pointer(uint32(opcode))
+
+	cell.ResetCounters()
+	name, _, err := abi.MessageDecoder(cell)
+	if err != nil {
+		return msgOpCode, nil
+	}
+	return msgOpCode, &name
 }
 
 func (b *BlockchainSource) Run(ctx context.Context) chan indexer.IDandBlock {
@@ -57,10 +85,18 @@ func (b *BlockchainSource) Run(ctx context.Context) chan indexer.IDandBlock {
 			case block := <-blockCh:
 				transactions := block.Block.AllTransactions()
 				for _, tx := range transactions {
+					var msgOpCode *uint32
+					var msgOpName *abi.MsgOpName
+					if tx.Msgs.InMsg.Exists {
+						cell := boc.Cell(tx.Msgs.InMsg.Value.Value.Body.Value)
+						msgOpCode, msgOpName = msgOpCodeAndName(&cell)
+					}
 					ch <- TransactionEvent{
 						AccountID: *tongo.NewAccountId(block.ID.Workchain, tx.AccountAddr),
 						Lt:        tx.Lt,
 						TxHash:    tx.Hash().Hex(),
+						MsgOpName: msgOpName,
+						MsgOpCode: msgOpCode,
 					}
 				}
 			}

--- a/pkg/pusher/sources/blockchain_source_test.go
+++ b/pkg/pusher/sources/blockchain_source_test.go
@@ -1,0 +1,129 @@
+package sources
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tonkeeper/opentonapi/internal/g"
+	"github.com/tonkeeper/tongo"
+	"github.com/tonkeeper/tongo/liteapi"
+	"github.com/tonkeeper/tongo/ton"
+	"go.uber.org/zap"
+
+	"github.com/tonkeeper/opentonapi/pkg/blockchain/indexer"
+)
+
+type mockTxDispatcher struct {
+	ch chan TransactionEvent
+}
+
+func (m *mockTxDispatcher) RegisterSubscriber(fn DeliveryFn, options SubscribeToTransactionsOptions) CancelFn {
+	panic("implement me")
+}
+func (m *mockTxDispatcher) Run(ctx context.Context) chan TransactionEvent {
+	return m.ch
+}
+
+func TestBlockchainSource_Run(t *testing.T) {
+	cli, err := liteapi.NewClient(liteapi.Mainnet(), liteapi.FromEnvs())
+	require.Nil(t, err)
+
+	tests := []struct {
+		name       string
+		blockID    string
+		wantEvents []TransactionEvent
+	}{
+		{
+			blockID: "(0,8000000000000000,40007846)",
+			wantEvents: []TransactionEvent{
+
+				{
+					AccountID: ton.MustParseAccountID("0:623d1fbe2220bb6e1076473d548ef250a1b6aaea35bce50f2fe99c31af6169a8"),
+					Lt:        42562202000001,
+					TxHash:    "0c9e611b886152d5f882b46d492d6746adc4a4812ac1d6862b66c813403a9ab1",
+					MsgOpCode: g.Pointer(uint32(0x41b9a0a4)),
+				},
+				{
+					AccountID: ton.MustParseAccountID("0:1150b518b2626ad51899f98887f8824b70065456455f7fe2813f012699a4061f"),
+					Lt:        42562202000003,
+					TxHash:    "9bb69427ec3c41caa01f9169c39202adce8a00d5e014fb38cb572063f1a275d6",
+					MsgOpName: g.Pointer("JettonTransfer"),
+					MsgOpCode: g.Pointer(uint32(0xf8a7ea5)),
+				},
+				{
+					AccountID: ton.MustParseAccountID("0:779dcc815138d9500e449c5291e7f12738c23d575b5310000f6a253bd607384e"),
+					Lt:        42562202000005,
+					TxHash:    "f041fbc9d3ecbcd59be218b3e563f0499baa3c670a2caa4644be7c1ca3bfde09",
+					MsgOpName: g.Pointer("JettonNotify"),
+					MsgOpCode: g.Pointer(uint32(0x7362d09c)),
+				},
+				{
+					AccountID: ton.MustParseAccountID("0:ed6473ad55669ff54214eab9a32cf34b4c6c4d2cda20bcae7151994c46067043"),
+					Lt:        42562202000007,
+					TxHash:    "203a9fa3cf95353f06989a5227772f82d654a0ad64911c67a1a3b763c1bccdaa",
+					MsgOpCode: g.Pointer(uint32(0xfcf9e58f)),
+				},
+				{
+					AccountID: ton.MustParseAccountID("0:62cf96996cf63631ac1d5487c807a02ed5fba102198fd12b44b2b3cb7fcfc51b"),
+					Lt:        42562202000009,
+					TxHash:    "8cd2c2a9e299864f2d355a0e5ac2ea702eea0e4c57f90f060bc702893d56008e",
+					MsgOpCode: g.Pointer(uint32(0x3ebe5431)),
+				},
+				{
+					AccountID: ton.MustParseAccountID("0:ed6473ad55669ff54214eab9a32cf34b4c6c4d2cda20bcae7151994c46067043"),
+					Lt:        42562202000011,
+					TxHash:    "5bd8434e0a109442eb0697497b66e4a32f56b1fe6ea73cc819f0d443eb4fa5be",
+					MsgOpCode: g.Pointer(uint32(0x56dfeb8a)),
+				},
+				{
+					AccountID: ton.MustParseAccountID("0:fd4fc5368284b4a7fac703cc440f6fd4e284def1af3d5dfce3cde443c360684c"),
+					Lt:        42562202000013,
+					TxHash:    "f9e4fa3ade5c1eb2ac6638c1ee2757b451910c1f88957f3fa8483b386291700a",
+					MsgOpName: g.Pointer("JettonInternalTransfer"),
+					MsgOpCode: g.Pointer(uint32(0x178d4519)),
+				},
+				{
+					AccountID: ton.MustParseAccountID("0:623d1fbe2220bb6e1076473d548ef250a1b6aaea35bce50f2fe99c31af6169a8"),
+					Lt:        42562202000015,
+					TxHash:    "2095354e54e510bcf5df57e14bc608ffab6b3d9b4a64345c122246ba0534d195",
+					MsgOpName: g.Pointer("Excess"),
+					MsgOpCode: g.Pointer(uint32(0xd53276db)),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blockID, err := tongo.ParseBlockID(tt.blockID)
+			require.Nil(t, err)
+
+			mockDisp := &mockTxDispatcher{
+				ch: make(chan TransactionEvent),
+			}
+			b := &BlockchainSource{
+				logger:     zap.L(),
+				dispatcher: mockDisp,
+			}
+			blockCh := b.Run(context.Background())
+			extID, _, err := cli.LookupBlock(context.Background(), blockID, 1, nil, nil)
+			require.Nil(t, err)
+			block, err := cli.GetBlock(context.Background(), extID)
+			require.Nil(t, err)
+
+			txCounts := len(block.AllTransactions())
+
+			blockCh <- indexer.IDandBlock{
+				ID:    extID,
+				Block: &block,
+			}
+
+			var events []TransactionEvent
+			for i := 0; i < txCounts; i++ {
+				event := <-mockDisp.ch
+				events = append(events, event)
+			}
+			require.Equal(t, tt.wantEvents, events)
+		})
+	}
+}

--- a/pkg/pusher/sources/source.go
+++ b/pkg/pusher/sources/source.go
@@ -7,8 +7,10 @@ import (
 )
 
 type SubscribeToTransactionsOptions struct {
-	AllAccounts bool
-	Accounts    []tongo.AccountID
+	Accounts      []tongo.AccountID
+	AllAccounts   bool
+	Operations    []string
+	AllOperations bool
 }
 
 // DeliveryFn describes a callback that will be triggered once an event happens.

--- a/pkg/pusher/sse/handler_test.go
+++ b/pkg/pusher/sse/handler_test.go
@@ -1,0 +1,68 @@
+package sse
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tonkeeper/opentonapi/pkg/pusher/sources"
+	"github.com/tonkeeper/tongo"
+)
+
+type mockTxSource struct {
+	options sources.SubscribeToTransactionsOptions
+}
+
+func (m *mockTxSource) SubscribeToTransactions(ctx context.Context, deliveryFn sources.DeliveryFn, opts sources.SubscribeToTransactionsOptions) sources.CancelFn {
+	m.options = opts
+	return nil
+}
+
+var _ sources.TransactionSource = (*mockTxSource)(nil)
+
+func TestHandler_SubscribeToTransactions(t *testing.T) {
+	tests := []struct {
+		name        string
+		url         string
+		wantErr     bool
+		wantOptions sources.SubscribeToTransactionsOptions
+	}{
+		{
+			name: "all accounts",
+			url:  "/transactions?accounts=all",
+			wantOptions: sources.SubscribeToTransactionsOptions{
+				AllAccounts:   true,
+				AllOperations: true,
+			},
+		},
+		{
+			name: "specific accounts and operations",
+			url:  "/transactions?accounts=0:779dcc815138d9500e449c5291e7f12738c23d575b5310000f6a253bd607384e&operations=JettonBurn,0x11223344,0x55667788,JettonMint",
+			wantOptions: sources.SubscribeToTransactionsOptions{
+				Accounts: []tongo.AccountID{
+					tongo.MustParseAddress("0:779dcc815138d9500e449c5291e7f12738c23d575b5310000f6a253bd607384e").ID,
+				},
+				Operations: []string{
+					"JettonBurn",
+					"0x11223344",
+					"0x55667788",
+					"JettonMint",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := &mockTxSource{}
+			h := &Handler{
+				txSource: source,
+			}
+			request := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			err := h.SubscribeToTransactions(&session{}, request)
+			require.Nil(t, err)
+			require.Equal(t, tt.wantOptions, source.options)
+		})
+	}
+}

--- a/pkg/pusher/websocket/session_test.go
+++ b/pkg/pusher/websocket/session_test.go
@@ -3,11 +3,13 @@ package websocket
 import (
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tonkeeper/opentonapi/pkg/pusher/sources"
 	"github.com/tonkeeper/tongo"
+	"github.com/tonkeeper/tongo/ton"
 	"go.uber.org/zap"
 )
 
@@ -19,13 +21,14 @@ func Test_session_subscribeToTransactions(t *testing.T) {
 		want              string
 		wantSubscriptions map[tongo.AccountID]struct{}
 		wantEvents        int
+		wantOptions       []sources.SubscribeToTransactionsOptions
 	}{
 		{
 			name:              "all good",
 			subscriptionLimit: 3,
 			params: []string{
 				"-1:5555555555555555555555555555555555555555555555555555555555555555",
-				"0:5555555555555555555555555555555555555555555555555555555555555555",
+				"0:5555555555555555555555555555555555555555555555555555555555555555;operations=JettonBurn,0x00112233,JettonMint",
 			},
 			wantSubscriptions: map[tongo.AccountID]struct{}{
 				tongo.MustParseAccountID("-1:5555555555555555555555555555555555555555555555555555555555555555"): {},
@@ -33,6 +36,16 @@ func Test_session_subscribeToTransactions(t *testing.T) {
 			},
 			want:       `success! 2 new subscriptions created`,
 			wantEvents: 2,
+			wantOptions: []sources.SubscribeToTransactionsOptions{
+				{
+					Accounts:      []tongo.AccountID{ton.MustParseAccountID("-1:5555555555555555555555555555555555555555555555555555555555555555")},
+					AllOperations: true,
+				},
+				{
+					Accounts:   []tongo.AccountID{ton.MustParseAccountID("0:5555555555555555555555555555555555555555555555555555555555555555")},
+					Operations: []string{"JettonBurn", "0x00112233", "JettonMint"},
+				},
+			},
 		},
 		{
 			name:              "subscribe to account multiple times",
@@ -47,16 +60,24 @@ func Test_session_subscribeToTransactions(t *testing.T) {
 			},
 			want:       `success! 1 new subscriptions created`,
 			wantEvents: 1,
+			wantOptions: []sources.SubscribeToTransactionsOptions{
+				{
+					Accounts:      []tongo.AccountID{ton.MustParseAccountID("-1:5555555555555555555555555555555555555555555555555555555555555555")},
+					AllOperations: true,
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			var options []sources.SubscribeToTransactionsOptions
 			s := &session{
 				eventCh:           make(chan event, 10),
 				txSubscriptions:   map[tongo.AccountID]sources.CancelFn{},
 				subscriptionLimit: tt.subscriptionLimit,
 				txSource: &mockTxSource{
 					OnSubscribeToTransactions: func(ctx context.Context, deliveryFn sources.DeliveryFn, opts sources.SubscribeToTransactionsOptions) sources.CancelFn {
+						options = append(options, opts)
 						deliveryFn([]byte("msg"))
 						return func() {}
 					},
@@ -71,7 +92,10 @@ func Test_session_subscribeToTransactions(t *testing.T) {
 			require.Equal(t, tt.wantSubscriptions, subs)
 			close(s.eventCh)
 			require.Equal(t, tt.wantEvents, len(s.eventCh))
-
+			sort.Slice(options, func(i, j int) bool {
+				return options[i].Accounts[0].String() < options[j].Accounts[0].String()
+			})
+			require.Equal(t, tt.wantOptions, options)
 		})
 	}
 }
@@ -118,6 +142,64 @@ func Test_session_sendEvent(t *testing.T) {
 				events[event.Method] = struct{}{}
 			}
 			require.Equal(t, tt.wantEvents, events)
+		})
+	}
+}
+
+func Test_processParam(t *testing.T) {
+	tests := []struct {
+		name    string
+		param   string
+		want    *accountOptions
+		wantErr bool
+	}{
+		{
+			name:  "param contains an account",
+			param: "-1:5555555555555555555555555555555555555555555555555555555555555555",
+			want: &accountOptions{
+				Account: ton.MustParseAccountID("-1:5555555555555555555555555555555555555555555555555555555555555555"),
+			},
+		},
+		{
+			name:  "param contains an account with operations",
+			param: "-1:5555555555555555555555555555555555555555555555555555555555555555;operations=JettonBurn,0x00112233,JettonMint",
+			want: &accountOptions{
+				Account:    ton.MustParseAccountID("-1:5555555555555555555555555555555555555555555555555555555555555555"),
+				Operations: []string{"JettonBurn", "0x00112233", "JettonMint"},
+			},
+		},
+		{
+			name:  "param contains an account with empty operations",
+			param: "-1:5555555555555555555555555555555555555555555555555555555555555555;operations=",
+			want: &accountOptions{
+				Account: ton.MustParseAccountID("-1:5555555555555555555555555555555555555555555555555555555555555555"),
+			},
+		},
+		{
+			name:    "param contains an account with malformed operations",
+			param:   "-1:5555555555555555555555555555555555555555555555555555555555555555;ops=JettonBurn,0x00112233,JettonMint",
+			wantErr: true,
+		},
+		{
+			name:    "param contains a malformed account",
+			param:   "-15555555555555555555555555555555555555555555555555555555555555555",
+			wantErr: true,
+		},
+		{
+			name:    "param contains an account with malformed operations",
+			param:   "-1:5555555555555555555555555555555555555555555555555555555555555555;JettonBurn,0x00112233,JettonMint",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			options, err := processParam(tt.param)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, options)
 		})
 	}
 }


### PR DESCRIPTION
  This commit introduce a new feature: ability to subscribe to specific
set of operations on account.

 SSE method is extended to accept optional "operations" query parameter:
  `/v2/sse/accounts/transactions?accounts=<accounts>&operations=<comma-separated list of ops>`

 Websocket:
  subscribe_account takes in params with the following format:
     `<accountID>;operations=<comma-separated list of ops>`

  `";operations=<comma-separated list of ops>"` is optional, if not
configured, you'll be subscribed to all operations on account.