### PR TITLE
Emulate methods to accept both hex and base64 encoded boc

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -44,7 +44,7 @@ func main() {
 	}
 	mempool := sources.NewMemPool(log)
 	// mempoolChannel receives a copy of any payload that goes through our API method /v2/blockchain/message
-	mempoolChannel := mempool.Run(context.TODO())
+	mempoolChannel, emulationCh := mempool.Run(context.TODO())
 
 	msgSender, err := blockchain.NewMsgSender(cfg.App.LiteServers, []chan []byte{mempoolChannel})
 	if err != nil {
@@ -57,6 +57,7 @@ func main() {
 		api.WithExecutor(storage),
 		api.WithMessageSender(msgSender),
 		api.WithSpamFilter(spamFilter),
+		api.WithEmulationChannel(emulationCh),
 		api.WithTonConnectSecret(cfg.TonConnect.Secret),
 	)
 	if err != nil {

--- a/pkg/api/event_handlers.go
+++ b/pkg/api/event_handlers.go
@@ -230,7 +230,7 @@ func (h *Handler) GetAccountEvent(ctx context.Context, params oas.GetAccountEven
 }
 
 func (h *Handler) EmulateMessageToAccountEvent(ctx context.Context, request *oas.EmulateMessageToAccountEventReq, params oas.EmulateMessageToAccountEventParams) (*oas.AccountEvent, error) {
-	c, err := boc.DeserializeSinglRootBase64(request.Boc)
+	c, err := deserializeSingleBoc(request.Boc)
 	if err != nil {
 		return nil, toError(http.StatusBadRequest, err)
 	}
@@ -274,7 +274,7 @@ func (h *Handler) EmulateMessageToAccountEvent(ctx context.Context, request *oas
 }
 
 func (h *Handler) EmulateMessageToEvent(ctx context.Context, request *oas.EmulateMessageToEventReq, params oas.EmulateMessageToEventParams) (*oas.Event, error) {
-	c, err := boc.DeserializeSinglRootBase64(request.Boc)
+	c, err := deserializeSingleBoc(request.Boc)
 	if err != nil {
 		return nil, toError(http.StatusBadRequest, err)
 	}
@@ -322,7 +322,7 @@ func (h *Handler) EmulateMessageToEvent(ctx context.Context, request *oas.Emulat
 }
 
 func (h *Handler) EmulateMessageToTrace(ctx context.Context, request *oas.EmulateMessageToTraceReq, params oas.EmulateMessageToTraceParams) (*oas.Trace, error) {
-	c, err := boc.DeserializeSinglRootBase64(request.Boc)
+	c, err := deserializeSingleBoc(request.Boc)
 	if err != nil {
 		return nil, toError(http.StatusBadRequest, err)
 	}
@@ -407,7 +407,7 @@ func convertEmulationParameters(params []oas.EmulateMessageToWalletReqParamsItem
 }
 
 func (h *Handler) EmulateMessageToWallet(ctx context.Context, request *oas.EmulateMessageToWalletReq, params oas.EmulateMessageToWalletParams) (*oas.MessageConsequences, error) {
-	msgCell, err := boc.DeserializeSinglRootBase64(request.Boc)
+	msgCell, err := deserializeSingleBoc(request.Boc)
 	if err != nil {
 		return nil, toError(http.StatusBadRequest, err)
 	}

--- a/pkg/api/utils.go
+++ b/pkg/api/utils.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"fmt"
+
+	"github.com/tonkeeper/tongo/boc"
+)
+
+// deserializeBoc tries to deserialize boc string in base64 or hex format.
+func deserializeBoc(bocStr string) ([]*boc.Cell, error) {
+	cells, err := boc.DeserializeBocBase64(bocStr)
+	if err != nil {
+		return boc.DeserializeBocHex(bocStr)
+	}
+	return cells, nil
+}
+
+func deserializeSingleBoc(bocStr string) (*boc.Cell, error) {
+	cells, err := deserializeBoc(bocStr)
+	if err != nil {
+		return nil, err
+	}
+	if len(cells) != 1 {
+		return nil, fmt.Errorf("invalid boc roots number %v", len(cells))
+	}
+	return cells[0], nil
+}

--- a/pkg/core/trace.go
+++ b/pkg/core/trace.go
@@ -94,10 +94,10 @@ func hasInterface(interfacesList []abi.ContractInterface, name abi.ContractInter
 	return false
 }
 
-func visit(trace *Trace, fn func(trace *Trace)) {
+func Visit(trace *Trace, fn func(trace *Trace)) {
 	fn(trace)
 	for _, child := range trace.Children {
-		visit(child, fn)
+		Visit(child, fn)
 	}
 }
 
@@ -112,7 +112,7 @@ func CollectAdditionalInfo(ctx context.Context, infoSource InformationSource, tr
 	var getGemsContracts []tongo.AccountID
 	var basicNftSale []tongo.AccountID
 	var stonfiPoolIDs []tongo.AccountID
-	visit(trace, func(trace *Trace) {
+	Visit(trace, func(trace *Trace) {
 		// when we emulate a trace,
 		// we construct "trace.AdditionalInfo" in emulatedTreeToTrace for all accounts the trace touches.
 		// moreover, some accounts change their states and some of them are not exist in the blockchain,
@@ -153,7 +153,7 @@ func CollectAdditionalInfo(ctx context.Context, infoSource InformationSource, tr
 	if err != nil {
 		return err
 	}
-	visit(trace, func(trace *Trace) {
+	Visit(trace, func(trace *Trace) {
 		// when we emulate a trace,
 		// we construct "trace.AdditionalInfo" in emulatedTreeToTrace for all accounts the trace touches.
 		// moreover, some accounts change their states and some of them are not exist in the blockchain,

--- a/pkg/pusher/sources/mem_pool.go
+++ b/pkg/pusher/sources/mem_pool.go
@@ -3,49 +3,94 @@ package sources
 import (
 	"context"
 	"encoding/json"
+	"sort"
 	"sync"
 
+	"github.com/tonkeeper/tongo"
 	"go.uber.org/zap"
 )
 
 // MemPool implements "MemPoolSource" interface
 // and provides a method to subscribe to pending inbound messages.
+//
+// MemPool supports two types of subscribers: regular and emulation.
+// Regular subscriber receives a message payload once it lands in mempool.
+// Emulation subscriber receives a message payload and additional emulation results with a short delay required to emulate a trace.
 type MemPool struct {
 	logger *zap.Logger
 
-	mu          sync.Mutex
-	currentID   subscriberID
-	subscribers map[subscriberID]DeliveryFn
+	mu        sync.Mutex
+	currentID subscriberID
+	// regularSubscribers subscribed to mempool events.
+	regularSubscribers map[subscriberID]mempoolDeliveryFn
+	// emulationSubscribers subscribed to mempool events with emulation.
+	emulationSubscribers map[subscriberID]mempoolDeliveryFn
 }
 
 func NewMemPool(logger *zap.Logger) *MemPool {
 	return &MemPool{
-		logger:      logger,
-		currentID:   1,
-		subscribers: map[subscriberID]DeliveryFn{},
+		logger:               logger,
+		currentID:            1,
+		regularSubscribers:   map[subscriberID]mempoolDeliveryFn{},
+		emulationSubscribers: map[subscriberID]mempoolDeliveryFn{},
 	}
 }
 
 var _ MemPoolSource = (*MemPool)(nil)
 
-func (m *MemPool) SubscribeToMessages(ctx context.Context, deliveryFn DeliveryFn) (CancelFn, error) {
+type mempoolDeliveryFn func(eventData []byte, involvedAccounts map[tongo.AccountID]struct{})
+
+func createMempoolDeliveryFnBasedOnOptions(deliveryFn DeliveryFn, opts SubscribeToMempoolOptions) mempoolDeliveryFn {
+	if len(opts.Accounts) > 0 {
+		return func(eventData []byte, involvedAccounts map[tongo.AccountID]struct{}) {
+			if len(involvedAccounts) == 0 {
+				return
+			}
+			for _, account := range opts.Accounts {
+				if _, ok := involvedAccounts[account]; ok {
+					deliveryFn(eventData)
+					return
+				}
+			}
+		}
+	}
+	return func(eventData []byte, involvedAccounts map[tongo.AccountID]struct{}) {
+		deliveryFn(eventData)
+	}
+}
+
+func (m *MemPool) SubscribeToMessages(ctx context.Context, deliveryFn DeliveryFn, opts SubscribeToMempoolOptions) (CancelFn, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	subID := m.currentID
 	m.currentID += 1
-	m.subscribers[subID] = deliveryFn
+
+	if len(opts.Accounts) > 0 {
+		m.emulationSubscribers[subID] = createMempoolDeliveryFnBasedOnOptions(deliveryFn, opts)
+	} else {
+		m.regularSubscribers[subID] = createMempoolDeliveryFnBasedOnOptions(deliveryFn, opts)
+	}
 	return func() {
 		m.mu.Lock()
 		defer m.mu.Unlock()
-		delete(m.subscribers, subID)
+		delete(m.regularSubscribers, subID)
+		delete(m.emulationSubscribers, subID)
 	}, nil
+
+}
+
+// PayloadAndEmulationResults contains a message payload and a list of accounts that are involved in the corresponding trace.
+type PayloadAndEmulationResults struct {
+	Payload  []byte
+	Accounts map[tongo.AccountID]struct{}
 }
 
 // Run runs a goroutine with a fan-out event-loop that resends an incoming payload to all subscribers.
-func (m *MemPool) Run(ctx context.Context) chan []byte {
+func (m *MemPool) Run(ctx context.Context) (chan []byte, chan PayloadAndEmulationResults) {
 	// TODO: replace with elastic channel
 	ch := make(chan []byte, 100)
+	emulationCh := make(chan PayloadAndEmulationResults, 100)
 	go func() {
 		for {
 			select {
@@ -53,10 +98,12 @@ func (m *MemPool) Run(ctx context.Context) chan []byte {
 				return
 			case payload := <-ch:
 				m.sendPayloadToSubscribers(payload)
+			case payload := <-emulationCh:
+				m.sendPayloadToEmulationSubscribers(payload)
 			}
 		}
 	}()
-	return ch
+	return ch, emulationCh
 }
 
 func (m *MemPool) sendPayloadToSubscribers(payload []byte) {
@@ -72,7 +119,32 @@ func (m *MemPool) sendPayloadToSubscribers(payload []byte) {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	for _, fn := range m.subscribers {
-		fn(eventData)
+	for _, fn := range m.regularSubscribers {
+		fn(eventData, nil)
+	}
+}
+
+func (m *MemPool) sendPayloadToEmulationSubscribers(payload PayloadAndEmulationResults) {
+	msg := EmulationMessageEventData{
+		BOC:              payload.Payload,
+		InvolvedAccounts: make([]tongo.AccountID, 0, len(payload.Accounts)),
+	}
+	for account := range payload.Accounts {
+		msg.InvolvedAccounts = append(msg.InvolvedAccounts, account)
+	}
+	sort.Slice(msg.InvolvedAccounts, func(i, j int) bool {
+		// TODO: add quick sorting capability to tongo.AccountID
+		return msg.InvolvedAccounts[i].ToRaw() < msg.InvolvedAccounts[j].ToRaw()
+	})
+	eventData, err := json.Marshal(msg)
+	if err != nil {
+		m.logger.Error("mempool failed to marshal payload to json",
+			zap.Error(err))
+		return
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, fn := range m.emulationSubscribers {
+		fn(eventData, payload.Accounts)
 	}
 }

--- a/pkg/pusher/sources/mem_pool_test.go
+++ b/pkg/pusher/sources/mem_pool_test.go
@@ -9,39 +9,65 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tonkeeper/tongo"
+	"github.com/tonkeeper/tongo/ton"
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
 )
 
+var testAccount1 = ton.MustParseAccountID("0:0a95e1d4ebe7860d051f8b861730dbdee1440fd11180211914e0089146580351")
+var testAccount2 = ton.MustParseAccountID("0:0a95e1d4ebe7860d051f8b861730dbdee1440fd11180211914e0089146580352")
+
 func TestMemPool_Run(t *testing.T) {
+
 	mempool := NewMemPool(zap.L())
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	ch := mempool.Run(ctx)
+	ch, emulationCh := mempool.Run(ctx)
 	const eventsNumber = 10
 
 	var wg sync.WaitGroup
-	wg.Add(eventsNumber)
+	wg.Add(eventsNumber * 2)
 
+	// subscribe to mempool events
 	eventDataCh := make(chan []byte, eventsNumber)
 	cancelFn, err := mempool.SubscribeToMessages(context.Background(), func(eventData []byte) {
 		eventDataCh <- eventData
 		wg.Done()
-	})
+	}, SubscribeToMempoolOptions{})
 	require.Nil(t, err)
+
+	// subscribe to mempool events with emulation
+	emulationEventDataCh := make(chan []byte, eventsNumber)
+	emulationCancelFn, err := mempool.SubscribeToMessages(context.Background(), func(eventData []byte) {
+		emulationEventDataCh <- eventData
+		wg.Done()
+	}, SubscribeToMempoolOptions{Accounts: []tongo.AccountID{testAccount1}})
+	require.Nil(t, err)
+
 	defer cancelFn()
+	defer emulationCancelFn()
 
 	var expected [][]byte
+	var emulationExpected [][]byte
+
 	for i := 0; i < eventsNumber; i++ {
 		payload := []byte(fmt.Sprintf("payload-%d", i))
 		ch <- payload
 		eventData, err := json.Marshal(MessageEventData{BOC: payload})
 		require.Nil(t, err)
 		expected = append(expected, eventData)
+
+		emPayload := []byte(fmt.Sprintf("emulation-payload-%d", i))
+		emulationCh <- PayloadAndEmulationResults{Payload: emPayload, Accounts: map[tongo.AccountID]struct{}{testAccount1: {}}}
+		eventData, err = json.Marshal(EmulationMessageEventData{BOC: emPayload, InvolvedAccounts: []tongo.AccountID{testAccount1}})
+		require.Nil(t, err)
+		emulationExpected = append(emulationExpected, eventData)
 	}
 	wg.Wait()
 	close(eventDataCh)
+	close(emulationEventDataCh)
 
 	var events [][]byte
 	for data := range eventDataCh {
@@ -49,9 +75,15 @@ func TestMemPool_Run(t *testing.T) {
 	}
 	require.Equal(t, expected, events)
 
+	events = [][]byte{}
+	for data := range emulationEventDataCh {
+		events = append(events, data)
+	}
+	require.Equal(t, emulationExpected, events)
+
 }
 
-func compareSubscribers(t *testing.T, expected []subscriberID, subscribers map[subscriberID]DeliveryFn) {
+func compareSubscribers(t *testing.T, expected []subscriberID, subscribers map[subscriberID]mempoolDeliveryFn) {
 	keys := maps.Keys(subscribers)
 	sort.Slice(keys, func(i, j int) bool {
 		return keys[i] < keys[j]
@@ -64,20 +96,80 @@ func TestMemPool_SubscribeToMessages(t *testing.T) {
 	cancelFns := map[subscriberID]CancelFn{}
 	for i := 0; i < 5; i++ {
 		subID := mempool.currentID
-		cancel, err := mempool.SubscribeToMessages(context.Background(), func(eventData []byte) {})
+		cancel, err := mempool.SubscribeToMessages(context.Background(), func(eventData []byte) {}, SubscribeToMempoolOptions{})
 		require.Nil(t, err)
 		cancelFns[subID] = cancel
 	}
-	compareSubscribers(t, []subscriberID{1, 2, 3, 4, 5}, mempool.subscribers)
+	for i := 0; i < 5; i++ {
+		subID := mempool.currentID
+		options := SubscribeToMempoolOptions{Accounts: []tongo.AccountID{{}}}
+		cancel, err := mempool.SubscribeToMessages(context.Background(), func(eventData []byte) {}, options)
+		require.Nil(t, err)
+		cancelFns[subID] = cancel
+	}
+	compareSubscribers(t, []subscriberID{1, 2, 3, 4, 5}, mempool.regularSubscribers)
+	compareSubscribers(t, []subscriberID{6, 7, 8, 9, 10}, mempool.emulationSubscribers)
 
 	cancelFns[3]()
-	compareSubscribers(t, []subscriberID{1, 2, 4, 5}, mempool.subscribers)
+	compareSubscribers(t, []subscriberID{1, 2, 4, 5}, mempool.regularSubscribers)
+	compareSubscribers(t, []subscriberID{6, 7, 8, 9, 10}, mempool.emulationSubscribers)
 
 	cancelFns[2]()
 	cancelFns[4]()
-	compareSubscribers(t, []subscriberID{1, 5}, mempool.subscribers)
+	cancelFns[9]()
+	cancelFns[10]()
+	compareSubscribers(t, []subscriberID{1, 5}, mempool.regularSubscribers)
+	compareSubscribers(t, []subscriberID{6, 7, 8}, mempool.emulationSubscribers)
 
 	cancelFns[1]()
 	cancelFns[1]()
-	compareSubscribers(t, []subscriberID{5}, mempool.subscribers)
+	cancelFns[6]()
+	cancelFns[6]()
+	compareSubscribers(t, []subscriberID{5}, mempool.regularSubscribers)
+	compareSubscribers(t, []subscriberID{7, 8}, mempool.emulationSubscribers)
+}
+
+func Test_createMempoolDeliveryFnBasedOnOptions(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       SubscribeToMempoolOptions
+		callFn     func(fn mempoolDeliveryFn)
+		wantCalled bool
+	}{
+		{
+			name: "no accounts",
+			opts: SubscribeToMempoolOptions{Accounts: nil},
+			callFn: func(fn mempoolDeliveryFn) {
+				fn([]byte("event"), nil)
+			},
+			wantCalled: true,
+		},
+		{
+			name: "involved account in options",
+			opts: SubscribeToMempoolOptions{Accounts: []tongo.AccountID{testAccount1}},
+			callFn: func(fn mempoolDeliveryFn) {
+				fn([]byte("event"), map[tongo.AccountID]struct{}{testAccount1: {}})
+			},
+			wantCalled: true,
+		},
+		{
+			name: "involved account not in options",
+			opts: SubscribeToMempoolOptions{Accounts: []tongo.AccountID{testAccount2}},
+			callFn: func(fn mempoolDeliveryFn) {
+				fn([]byte("event"), map[tongo.AccountID]struct{}{testAccount1: {}})
+			},
+			wantCalled: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			called := false
+			delivery := func(eventData []byte) {
+				called = true
+			}
+			fn := createMempoolDeliveryFnBasedOnOptions(delivery, tt.opts)
+			tt.callFn(fn)
+			require.Equal(t, tt.wantCalled, called)
+		})
+	}
 }

--- a/pkg/pusher/sources/source.go
+++ b/pkg/pusher/sources/source.go
@@ -13,6 +13,13 @@ type SubscribeToTransactionsOptions struct {
 	AllOperations bool
 }
 
+// SubscribeToMempoolOptions configures subscription to mempool events.
+type SubscribeToMempoolOptions struct {
+	// Emulation if set, opentonapi will send a message payload and additionally a list of accounts
+	// that are involved in the corresponding trace.
+	Accounts []tongo.AccountID
+}
+
 // DeliveryFn describes a callback that will be triggered once an event happens.
 type DeliveryFn func(eventData []byte)
 
@@ -38,7 +45,18 @@ type MessageEventData struct {
 	BOC []byte `json:"boc"`
 }
 
+// EmulationMessageEventData represents a notification about a new pending inbound message.
+// After opentonapi receives a message, it emulates what happens when the message lands on the blockchain.
+// Then it sends the message and the emulation results to subscribers.
+// This is part of our API contract with subscribers.
+type EmulationMessageEventData struct {
+	BOC []byte `json:"boc"`
+	// InvolvedAccounts is a list of accounts that are involved in the corresponding trace of the message.
+	// The trace is a result of emulation.
+	InvolvedAccounts []tongo.AccountID `json:"involved_accounts"`
+}
+
 // MemPoolSource provides a method to subscribe to notifications about pending inbound messages.
 type MemPoolSource interface {
-	SubscribeToMessages(ctx context.Context, deliveryFn DeliveryFn) (CancelFn, error)
+	SubscribeToMessages(ctx context.Context, deliveryFn DeliveryFn, opts SubscribeToMempoolOptions) (CancelFn, error)
 }

--- a/pkg/pusher/websocket/handler_test.go
+++ b/pkg/pusher/websocket/handler_test.go
@@ -25,11 +25,11 @@ func (m *mockTxSource) SubscribeToTransactions(ctx context.Context, deliveryFn s
 }
 
 type mockMemPool struct {
-	OnSubscribeToMessages func(ctx context.Context, deliveryFn sources.DeliveryFn) (sources.CancelFn, error)
+	OnSubscribeToMessages func(ctx context.Context, deliveryFn sources.DeliveryFn, opts sources.SubscribeToMempoolOptions) (sources.CancelFn, error)
 }
 
-func (m *mockMemPool) SubscribeToMessages(ctx context.Context, deliveryFn sources.DeliveryFn) (sources.CancelFn, error) {
-	return m.OnSubscribeToMessages(ctx, deliveryFn)
+func (m *mockMemPool) SubscribeToMessages(ctx context.Context, deliveryFn sources.DeliveryFn, opts sources.SubscribeToMempoolOptions) (sources.CancelFn, error) {
+	return m.OnSubscribeToMessages(ctx, deliveryFn, opts)
 }
 
 type mockTraceSource struct {
@@ -58,7 +58,7 @@ func TestHandler_UnsubscribeWhenConnectionIsClosed(t *testing.T) {
 	var memPoolSubscribed atomic.Bool   // to make "go test -race" happy
 	var memPoolUnsubscribed atomic.Bool // to make "go test -race" happy
 	mempool := &mockMemPool{
-		OnSubscribeToMessages: func(ctx context.Context, deliveryFn sources.DeliveryFn) (sources.CancelFn, error) {
+		OnSubscribeToMessages: func(ctx context.Context, deliveryFn sources.DeliveryFn, opts sources.SubscribeToMempoolOptions) (sources.CancelFn, error) {
 			memPoolSubscribed.Store(true)
 			return func() {
 				memPoolUnsubscribed.Store(true)
@@ -160,7 +160,7 @@ func TestHandler_UnsubscribeMethods(t *testing.T) {
 	var memPoolSubscribed atomic.Bool   // to make "go test -race" happy
 	var memPoolUnsubscribed atomic.Bool // to make "go test -race" happy
 	mempool := &mockMemPool{
-		OnSubscribeToMessages: func(ctx context.Context, deliveryFn sources.DeliveryFn) (sources.CancelFn, error) {
+		OnSubscribeToMessages: func(ctx context.Context, deliveryFn sources.DeliveryFn, opts sources.SubscribeToMempoolOptions) (sources.CancelFn, error) {
 			memPoolSubscribed.Store(true)
 			return func() {
 				memPoolUnsubscribed.Store(true)


### PR DESCRIPTION
* Emulate methods to accept both hex and base64 encoded boc
* Fix mutex usage
* Implement mempool subscription with additional emulation results. 
  How to subscribe to mempool with emulation results:
      /v2/sse/mempool?accounts=<comma-separated-list-of-accounts> for sse
     "subscribe_mempool" with params=["accounts=<comma-separated-list-of-accounts>"] for websocket. 



