### PR TITLE
Change type of total_weight in ValidatorSet to string

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -5024,8 +5024,8 @@
       "type": "integer"
      },
      "total_weight": {
-      "format": "int64",
-      "type": "integer"
+      "example": "1152921504606846800",
+      "type": "string"
      },
      "utime_since": {
       "type": "integer"

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -3655,8 +3655,8 @@ components:
         main:
           type: integer
         total_weight:
-          type: integer
-          format: int64
+          type: string
+          example: "1152921504606846800"
         list:
           type: array
           items:

--- a/pkg/api/blockchain_converters.go
+++ b/pkg/api/blockchain_converters.go
@@ -822,7 +822,7 @@ func convertValidatorSet(set tlb.ValidatorsSet) oas.OptValidatorsSet {
 		l = set.Validators.List.Values()
 	} else {
 		l = set.ValidatorsExt.List.Values()
-		s.TotalWeight = oas.NewOptInt64(int64(set.ValidatorsExt.TotalWeight))
+		s.TotalWeight = oas.NewOptString(fmt.Sprintf("%d", int64(set.ValidatorsExt.TotalWeight)))
 	}
 	for _, d := range l {
 		item := oas.ValidatorsSetListItem{

--- a/pkg/api/testdata/config-params-1.json
+++ b/pkg/api/testdata/config-params-1.json
@@ -258,7 +258,7 @@
      "utime_until": 1698385672,
      "total": 322,
      "main": 100,
-     "total_weight": 1152921504606846813,
+     "total_weight": "1152921504606846813",
      "list": [
        {
          "public_key": "173dd51384ae444912382b94ad824596d36fc83788cc4f09d9f2f02eae5cc9ee",
@@ -1877,7 +1877,7 @@
      "utime_until": 1698451208,
      "total": 316,
      "main": 100,
-     "total_weight": 1152921504606846821,
+     "total_weight": "1152921504606846821",
      "list": [
        {
          "public_key": "71207e97efef4bf155b77795525636602d6fb31c2bdd0aec485200199db9a0df",

--- a/pkg/oas/oas_schemas_gen.go
+++ b/pkg/oas/oas_schemas_gen.go
@@ -14866,7 +14866,7 @@ type ValidatorsSet struct {
 	UtimeUntil  int                     `json:"utime_until"`
 	Total       int                     `json:"total"`
 	Main        int                     `json:"main"`
-	TotalWeight OptInt64                `json:"total_weight"`
+	TotalWeight OptString               `json:"total_weight"`
 	List        []ValidatorsSetListItem `json:"list"`
 }
 
@@ -14891,7 +14891,7 @@ func (s *ValidatorsSet) GetMain() int {
 }
 
 // GetTotalWeight returns the value of TotalWeight.
-func (s *ValidatorsSet) GetTotalWeight() OptInt64 {
+func (s *ValidatorsSet) GetTotalWeight() OptString {
 	return s.TotalWeight
 }
 
@@ -14921,7 +14921,7 @@ func (s *ValidatorsSet) SetMain(val int) {
 }
 
 // SetTotalWeight sets the value of TotalWeight.
-func (s *ValidatorsSet) SetTotalWeight(val OptInt64) {
+func (s *ValidatorsSet) SetTotalWeight(val OptString) {
 	s.TotalWeight = val
 }
 


### PR DESCRIPTION
  Two methods are affected:
   /v2/blockchain/config
   /v2/blockchain/masterchain/{masterchain_seqno}/config

  The issue is that total_weight is quite big
  and javascript doesn't like that.