### PR TITLE
Return the REAL jetton symbol

### DIFF
--- a/pkg/api/normalized_metadata.go
+++ b/pkg/api/normalized_metadata.go
@@ -46,7 +46,6 @@ func NormalizeMetadata(meta tep64.Metadata, info *addressbook.KnownJetton, isBla
 	verification := VerificationNone
 	if isBlacklisted {
 		verification = VerificationBlacklist
-		symbol = "SCAM"
 	}
 	name := meta.Name
 	if name == "" {


### PR DESCRIPTION
I think you don't have the right to change the actual metadata that we get from the blockchain.

It's definitely not in line with the principles of decentralization.

Frankly, it makes me question the credibility of TONAPI.