### PR TITLE
Fix request body decoding mistake in SendRawMessage

### DIFF
--- a/pkg/api/liteserver_handlers.go
+++ b/pkg/api/liteserver_handlers.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"context"
-	"encoding/json"
+	"encoding/base64"
 	"net/http"
 	"time"
 
@@ -88,7 +88,7 @@ func (h *Handler) GetRawBlockchainBlockHeader(ctx context.Context, params oas.Ge
 }
 
 func (h *Handler) SendRawMessage(ctx context.Context, request *oas.SendRawMessageReq) (*oas.SendRawMessageOK, error) {
-	payload, err := json.Marshal(request.Body)
+	payload, err := base64.StdEncoding.DecodeString(request.Body)
 	if err != nil {
 		return nil, toError(http.StatusBadRequest, err)
 	}


### PR DESCRIPTION
While trying to use the `/v2/liteserver/send_message` api as described on https://tonapi.io/api-v2, I ran into the issue where the server doesn't seem to accept any formats of the boc messages I sent, whether it's base64, hex string, hex string with 0x, or even integer. It returns status code 500 with the exception message "unknown magic prefix", which is thrown [here](https://github.com/tonkeeper/tongo/blob/6ffffada77769aa038de8db3aa12b9a13dd25064/boc/boc.go#L96).

After investigating, I found that the issue is at [liteserver_handlers.go#L91](https://github.com/tonkeeper/opentonapi/blob/281941402cc70abe4e09f792e6b656a2d9a72eae/pkg/api/liteserver_handlers.go#L91)
```
payload, err := json.Marshal(request.Body)
```

Firstly, `json.Marshal` will puts a 0x22 (or `"`) at the beginning and the end of `payload`, secondly, it can't handle bytes string this way.

For example `json.Marshal("abc")` outputs `22 61 62 63 22`, and `json.Marshal("\x00\x01\x02")` outputs `22 5c 75 30 30 30 30 5c 75 30 30 30 31 5c 75 30 30 30 32 22`.

This issue has been there since 6f41163788f40f8be960dc0d87b8fc7e4109fd45, that's 9 months ago. I'm not sure if this intentional or not. I suspect there were some changes in the way tongo handles the payload but opentonapi was not updated correctly.

The fix was to use `base64.StdEncoding.DecodeString(request.Body)`. Now we're able to send boc's encoded in base64.