### PR TITLE
Allow configuration to track all accounts

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -46,6 +46,7 @@ func main() {
 		log,
 		client,
 		litestorage.WithPreloadAccounts(cfg.App.Accounts),
+		litestorage.WithTrackAllAccounts(cfg.App.TrackAllAccounts),
 		litestorage.WithTFPools(book.TFPools()),
 		litestorage.WithKnownJettons(maps.Keys(book.GetKnownJettons())),
 		litestorage.WithBlockChannel(storageBlockCh),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 		LogLevel           string              `env:"LOG_LEVEL" envDefault:"INFO"`
 		MetricsPort        int                 `env:"METRICS_PORT" envDefault:"9010"`
 		Accounts           accountsList        `env:"ACCOUNTS"`
+		TrackAllAccounts   bool                `env:"TRACK_ALL_ACCOUNTS" envDefault:"false"`
 		LiteServers        []config.LiteServer `env:"LITE_SERVERS"`
 		SendingLiteservers []config.LiteServer `env:"SENDING_LITE_SERVERS"`
 		IsTestnet          bool                `env:"IS_TESTNET" envDefault:"false"`


### PR DESCRIPTION
This PR adds an env var configuration called `TRACK_ALL_ACCOUNTS`

setting this env var to true, will allow to track all accounts instead of ore-defined specific accounts