### PR TITLE
update getgems verified collection api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/puzpuzpuz/xsync/v2 v2.4.0
 	github.com/shopspring/decimal v1.3.1
-	github.com/shurcooL/graphql v0.0.0-20220606043923-3cf50f8a0a29
 	github.com/sourcegraph/conc v0.3.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tonkeeper/scam_backoffice_rules v0.0.0-20241106130559-c44de2d4177b

--- a/pkg/addressbook/addressbook.go
+++ b/pkg/addressbook/addressbook.go
@@ -1,7 +1,6 @@
 package addressbook
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"github.com/tonkeeper/opentonapi/pkg/core"
@@ -19,7 +18,6 @@ import (
 	"time"
 
 	"github.com/shopspring/decimal"
-	"github.com/shurcooL/graphql"
 	"github.com/tonkeeper/tongo"
 	"go.uber.org/zap"
 	"golang.org/x/exp/maps"
@@ -489,19 +487,13 @@ func (b *Book) getGGWhitelist() error {
 }
 
 func fetchGetGemsVerifiedCollections() ([]tongo.AccountID, error) {
-	client := graphql.NewClient("https://api.getgems.io/graphql", nil)
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-	var q struct {
-		GetAddressesOfVerifiedCollections []graphql.String `graphql:"getAddressesOfVerifiedCollections"`
-	}
-	err := client.Query(ctx, &q, nil)
+	res, err := downloadJson[string]("https://api.getgems.io/public/api/verified-collections")
 	if err != nil {
 		return nil, err
 	}
-	accountIDs := make([]tongo.AccountID, 0, len(q.GetAddressesOfVerifiedCollections))
-	for _, collection := range q.GetAddressesOfVerifiedCollections {
-		account, err := tongo.ParseAddress(string(collection))
+	accountIDs := make([]tongo.AccountID, 0, len(res))
+	for _, collection := range res {
+		account, err := tongo.ParseAddress(collection)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Для верифицированных коллекций появилась новое REST API, данные такие-же как и в GraphQL, но для гетгемс это апи "дешевле" потому что GET запрос кешируется на CDN. В GraphQL использовался POST запрос без кешей