### PR TITLE
Add straw merge metrics

### DIFF
--- a/pkg/bath/bath.go
+++ b/pkg/bath/bath.go
@@ -2,6 +2,7 @@ package bath
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/tonkeeper/opentonapi/pkg/core"
 	"github.com/tonkeeper/tongo"
@@ -61,9 +62,9 @@ func FindActions(ctx context.Context, trace *core.Trace, opts ...Option) (*Actio
 }
 
 func MergeAllBubbles(bubble *Bubble, straws []Merger) {
-	for _, s := range straws {
+	for i, s := range straws {
 		for {
-			success := recursiveMerge(bubble, s)
+			success := recursiveMerge(bubble, s, i)
 			if success {
 				continue
 			}
@@ -72,12 +73,13 @@ func MergeAllBubbles(bubble *Bubble, straws []Merger) {
 	}
 }
 
-func recursiveMerge(bubble *Bubble, s Merger) bool {
+func recursiveMerge(bubble *Bubble, s Merger, idx int) bool {
 	if s.Merge(bubble) {
+		strawSuccess.WithLabelValues(fmt.Sprintf("%d", idx)).Inc()
 		return true
 	}
 	for _, b := range bubble.Children {
-		if recursiveMerge(b, s) {
+		if recursiveMerge(b, s, idx) {
 			return true
 		}
 	}

--- a/pkg/bath/straw_metrics.go
+++ b/pkg/bath/straw_metrics.go
@@ -1,0 +1,14 @@
+package bath
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var strawSuccess = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Name: "bath_straw_success_total",
+		Help: "Number of successful merges per straw index",
+	},
+	[]string{"index"},
+)


### PR DESCRIPTION
## Summary
- instrument straw merges in bath
- add Prometheus metrics to count merges per straw index
- move metrics directly into bath package

## Testing
- `go test ./...` *(fails: undefined reference errors and blocked URLs)*

------
https://chatgpt.com/codex/tasks/task_e_6861734b897c8331a019f4059848764b