### PR TITLE
fix(api): guard nil AccountID in getAdditionalInfoStonfi (panic on addr_none pool tokens)

### DIFF
--- a/pkg/api/emulation.go
+++ b/pkg/api/emulation.go
@@ -447,7 +447,7 @@ func EmulatedTreeToTrace(
 func getAdditionalInfoStonfi(ctx context.Context, sharedExecutor *shardsAccountExecutor, additionalInfo *core.TraceAdditionalInfo, token0, token1 tlb.MsgAddress) {
 	t0, err0 := ton.AccountIDFromTlb(token0)
 	t1, err1 := ton.AccountIDFromTlb(token1)
-	if err1 != nil || err0 != nil {
+	if err1 != nil || err0 != nil || t0 == nil || t1 == nil {
 		return
 	}
 	additionalInfo.STONfiPool = &core.STONfiPool{
@@ -461,6 +461,9 @@ func getAdditionalInfoStonfi(ctx context.Context, sharedExecutor *shardsAccountE
 		}
 		data := value.(abi.GetWalletDataResult)
 		master, _ := ton.AccountIDFromTlb(data.Jetton)
+		if master == nil {
+			continue
+		}
 		additionalInfo.SetJettonMaster(accountID, *master)
 	}
 }

--- a/pkg/api/emulation_stonfi_nil_test.go
+++ b/pkg/api/emulation_stonfi_nil_test.go
@@ -1,0 +1,26 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tonkeeper/opentonapi/pkg/core"
+	"github.com/tonkeeper/tongo/tlb"
+)
+
+// TestStonfiNilAddressNoPanic is the regression test for the getAdditionalInfoStonfi
+// nil-pointer dereference: ton.AccountIDFromTlb returns (nil, nil) for addr_none /
+// addr_extern, so a STONfi pool reporting an addr_none token address used to panic
+// the serving goroutine. After the guard, the function returns gracefully without
+// setting STONfiPool. (On the unpatched code this test panics.)
+func TestStonfiNilAddressNoPanic(t *testing.T) {
+	none := tlb.MsgAddress{SumType: "AddrNone"}
+	info := &core.TraceAdditionalInfo{}
+
+	// must not panic on addr_none token addresses
+	getAdditionalInfoStonfi(context.Background(), nil, info, none, none)
+
+	if info.STONfiPool != nil {
+		t.Fatalf("expected STONfiPool to be unset when token addresses are addr_none, got %+v", info.STONfiPool)
+	}
+}


### PR DESCRIPTION
## What

`getAdditionalInfoStonfi` (`pkg/api/emulation.go`) panics with a nil-pointer
dereference when a STONfi pool's `get_pool_data` returns a token address of
`addr_none` (or `addr_extern`).

`ton.AccountIDFromTlb` returns `(nil, nil)` - a nil pointer **and** a nil error -
for `AddrNone`/`AddrExtern`, but the function only checks the error before
dereferencing the returned pointer:

```go
t0, err0 := ton.AccountIDFromTlb(token0)
t1, err1 := ton.AccountIDFromTlb(token1)
if err1 != nil || err0 != nil {   // nil pointer not checked
    return
}
additionalInfo.STONfiPool = &core.STONfiPool{
    Token0: *t0,                  // panics if token0 == addr_none
    ...
    additionalInfo.SetJettonMaster(accountID, *master)  // panics if data.Jetton == addr_none
```

So emulating any trace that inspects such a contract panics the serving goroutine.

## Why it's a clear bug, not an invariant

The NFT/jetton branch in the same function already guards exactly this pattern:

```go
master, _ := ton.AccountIDFromTlb(data.Jetton)
if master == nil {
    continue
}
```

`getAdditionalInfoStonfi` simply omits the check on its three dereference sites.

## Fix

Add the nil-pointer guards, mirroring the existing sibling branch (return early if
either token resolves to a nil `AccountID`; skip the jetton-master deref if it
does). One line per site, no behavior change for valid addresses.

## Test

Adds `TestStonfiNilAddressNoPanic` (in `pkg/api/`): calls `getAdditionalInfoStonfi`
with `addr_none` token addresses and asserts it returns without panicking and
leaves `STONfiPool` unset. The test panics on the current code and passes with the
fix.

## Reproduction (before the fix)

A `get_pool_data` (method id 81689) returning a STONfi-shaped stack whose
`Token0Address`/`Token1Address` slices hold the 2-bit `addr_none` prefix decodes
cleanly via `abi.DecodeGetPoolData_StonfiResult` and then panics in
`getAdditionalInfoStonfi`: `runtime error: invalid memory address or nil pointer
dereference` at `emulation.go:454`.
