### PR TITLE
filter scam jettons out of account search

### DIFF
--- a/pkg/api/account_handlers.go
+++ b/pkg/api/account_handlers.go
@@ -334,8 +334,10 @@ func (h *Handler) SearchAccounts(ctx context.Context, params oas.SearchAccountsP
 	attachedAccounts := h.addressBook.SearchAttachedAccountsByPrefix(params.Name)
 	accounts := make([]addressbook.AttachedAccount, 0, len(attachedAccounts))
 	for _, account := range attachedAccounts {
-		if account.Symbol != "" {
-			trust := h.spamFilter.JettonTrust(account.Wallet, account.Symbol, account.Name, account.Preview)
+		if (account.Type == addressbook.JettonNameAccountType || account.Type == addressbook.JettonSymbolAccountType) &&
+			account.Trust != core.TrustWhitelist {
+			// name has " · jetton" suffix, slug is the original name
+			trust := h.spamFilter.JettonTrust(account.Wallet, account.Symbol, account.Slug, account.Preview)
 			if trust == core.TrustBlacklist {
 				continue
 			}


### PR DESCRIPTION
The jetton spam check in SearchAccounts was dead code: it was gated on `account.Symbol != ""`, but `AttachedAccount.Symbol` is never populated, so scam jettons ("Locked TON", "USDT (Locked)", ...) came back with `trust: none`.

- Gate the check on the attached-account type (`jetton_name`/`jetton_symbol`) instead of the never-set Symbol field
- Pass `Slug` (raw name) to JettonTrust instead of `Name`, which carries a " · jetton" suffix that would skew name matching
- Skip the check for address-book-whitelisted jettons so the name heuristic can never re-mark a known-good token
- Blacklisted jettons are dropped from the results