### PR TITLE
hide preview image for blacklisted jettons

### DIFF
--- a/pkg/api/jetton_converters.go
+++ b/pkg/api/jetton_converters.go
@@ -17,13 +17,17 @@ import (
 )
 
 func jettonPreview(master ton.AccountID, meta NormalizedMetadata, score int32, scaledUiParams *core.ScaledUIParameters) oas.JettonPreview {
+	image := meta.PreviewImage
+	if meta.Verification == core.TrustBlacklist {
+		image = ""
+	}
 	preview := oas.JettonPreview{
 		Address:      master.ToRaw(),
 		Name:         meta.Name,
 		Symbol:       meta.Symbol,
 		Verification: oas.JettonVerificationType(meta.Verification),
 		Decimals:     meta.Decimals,
-		Image:        meta.PreviewImage,
+		Image:        image,
 		Score:        score,
 	}
 	if meta.CustomPayloadApiUri != "" {
@@ -53,7 +57,7 @@ func jettonMetadata(account ton.AccountID, meta NormalizedMetadata) oas.JettonMe
 	if meta.Description != "" {
 		metadata.Description.SetTo(meta.Description)
 	}
-	if meta.Image != "" {
+	if meta.Image != "" && meta.Verification != core.TrustBlacklist {
 		metadata.Image.SetTo(meta.Image)
 	}
 	if meta.CustomPayloadApiUri != "" {
@@ -221,6 +225,10 @@ func (h *Handler) convertJettonBalance(ctx context.Context, wallet core.JettonWa
 func (h *Handler) convertJettonInfo(ctx context.Context, master core.JettonMaster, holders map[tongo.AccountID]int32, scaledUiParams *core.ScaledUIParameters) oas.JettonInfo {
 	meta := h.GetJettonNormalizedMetadata(ctx, master.Address)
 	metadata := jettonMetadata(master.Address, meta)
+	preview := meta.PreviewImage
+	if meta.Verification == core.TrustBlacklist {
+		preview = ""
+	}
 	info := oas.JettonInfo{
 		Mintable:     master.Mintable,
 		TotalSupply:  master.TotalSupply.String(),
@@ -228,7 +236,7 @@ func (h *Handler) convertJettonInfo(ctx context.Context, master core.JettonMaste
 		Verification: oas.JettonVerificationType(meta.Verification),
 		HoldersCount: holders[master.Address],
 		Admin:        convertOptAccountAddress(master.Admin, h.addressBook),
-		Preview:      meta.PreviewImage,
+		Preview:      preview,
 	}
 	if scaledUiParams != nil {
 		info.ScaledUI.SetTo(oas.ScaledUI{

--- a/pkg/api/jetton_converters_test.go
+++ b/pkg/api/jetton_converters_test.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/tonkeeper/opentonapi/pkg/core"
+	"github.com/tonkeeper/tongo/ton"
+)
+
+func TestJettonPreview_BlacklistedHasNoImage(t *testing.T) {
+	master := ton.MustParseAccountID("EQCynJJ1RdWNXJ9vMDOF0hofz352DQ796mbvgeDDb0xcIW-S")
+	meta := NormalizedMetadata{
+		Name:         "Tether",
+		Symbol:       "TON-USDT",
+		Verification: core.TrustBlacklist,
+		PreviewImage: "https://example.com/image.png",
+	}
+
+	preview := jettonPreview(master, meta, 0, nil)
+	require.Empty(t, preview.Image)
+
+	metadata := jettonMetadata(master, meta)
+	require.False(t, metadata.Image.IsSet())
+}
+
+func TestJettonPreview_NonBlacklistedKeepsImage(t *testing.T) {
+	master := ton.MustParseAccountID("EQCynJJ1RdWNXJ9vMDOF0hofz352DQ796mbvgeDDb0xcIW-S")
+	meta := NormalizedMetadata{
+		Name:         "Notcoin",
+		Symbol:       "NOT",
+		Verification: core.TrustNone,
+		PreviewImage: "https://example.com/image.png",
+		Image:        "https://example.com/image.png",
+	}
+
+	preview := jettonPreview(master, meta, 0, nil)
+	require.Equal(t, meta.PreviewImage, preview.Image)
+
+	metadata := jettonMetadata(master, meta)
+	require.True(t, metadata.Image.IsSet())
+	require.Equal(t, meta.Image, metadata.Image.Value)
+}

--- a/pkg/api/purchase_handlers.go
+++ b/pkg/api/purchase_handlers.go
@@ -138,13 +138,17 @@ func (h *Handler) convertPrice(ctx context.Context, price core.Price) oas.Price 
 		}
 	case core.CurrencyJetton:
 		meta := h.GetJettonNormalizedMetadata(ctx, *price.Currency.Jetton)
+		image := meta.PreviewImage
+		if meta.Verification == core.TrustBlacklist {
+			image = ""
+		}
 		res := oas.Price{
 			CurrencyType: oas.CurrencyTypeJetton,
 			Value:        price.Amount.String(),
 			Decimals:     meta.Decimals,
 			TokenName:    meta.Symbol,
 			Verification: oas.TrustType(meta.Verification),
-			Image:        meta.PreviewImage,
+			Image:        image,
 		}
 		res.Jetton.SetTo(price.Currency.Jetton.ToRaw())
 		return res


### PR DESCRIPTION
## Summary
Blacklisted jettons often reuse a legitimate coin's logo to look convincing (e.g. the
recent TON-USDT/USDC impersonators). Blank the image whenever a jetton's verification
is `blacklist`, instead of passing the (likely stolen) image through:
- `jettonPreview`
- `jettonMetadata`
- `convertJettonInfo` (the `Preview` field)
- the purchase price converter (`convertPrice`, `CurrencyJetton` case)

## Test plan
- [x] New unit tests in `pkg/api/jetton_converters_test.go` cover both the
      blacklisted (image blanked) and non-blacklisted (image kept) cases
- [x] `go build ./...` succeeds