### PR TITLE
fix: wallet actions execute in reverse order

### DIFF
--- a/pkg/api/migration_handlers.go
+++ b/pkg/api/migration_handlers.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"math/big"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -619,6 +620,9 @@ func inferWalletForAddress(address ton.AccountID, pubkey ed25519.PublicKey) (ton
 }
 
 func buildUnsignedBody(v tonwallet.Version, subWalletID uint32, pubkey ed25519.PublicKey, workchain int, seqno uint32, validUntil time.Time, s []tonwallet.RawMessage) (*boc.Cell, error) {
+	// actions are executed by wallet code in reverse order
+	s = slices.Clone(s)
+	slices.Reverse(s)
 	switch v {
 	case tonwallet.V3R1, tonwallet.V3R2:
 		body := tonwallet.MessageV3{


### PR DESCRIPTION
Wallet contracts (v3/v4/v5) execute their action list tail-first: each action recurses into the "next actions" cell before sending its own message, so messages actually run on-chain in the reverse of the order they're encoded in. Moves the reversal into `buildUnsignedBody` itself so every caller gets the correct on-chain execution order automatically.