### PR TITLE
fix panic on uninit account

### DIFF
--- a/pkg/api/event_handlers.go
+++ b/pkg/api/event_handlers.go
@@ -12,9 +12,10 @@ import (
 	"sync"
 	"time"
 
+	"slices"
+
 	"github.com/tonkeeper/opentonapi/internal/g"
 	"go.uber.org/zap"
-	"slices"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -677,7 +678,7 @@ func extractDestinationWallet(message tlb.Message) (*ton.AccountID, error) {
 }
 
 func prepareAccountState(accountID tongo.AccountID, state tlb.ShardAccount, startBalance int64) (tlb.ShardAccount, error) {
-	if state.Account.Status() == tlb.AccountActive {
+	if state.Account.SumType == "Account" && state.Account.Account.Storage.State.SumType == "AccountActive" {
 		state.Account.Account.Storage.Balance.Grams = tlb.Grams(startBalance)
 		state.Account.Account.StorageStat.StorageExtra.SumType = "StorageExtraNone"
 		return state, nil


### PR DESCRIPTION
## Summary
- \`prepareAccountState\` called \`state.Account.Status()\` unconditionally, which panics on a zero-value \`tlb.ShardAccount\` (its \`SumType\` isn't \`AccountNone\`/\`AccountActive\`/\`AccountFrozen\`).
- \`PrepareMigration\` hits this: for an uninitialized \`from\` wallet, \`seedState\` is left as a Go zero value (real state is only fetched for already-deployed/active wallets), and this panic killed the whole request with no recovery, surfacing as a 502.
- Fix checks the raw \`SumType\` fields instead of calling the panicking method, so a zero-value/never-fetched state is treated as simply "not active" instead of crashing.

## Test plan
- [x] Reproduced the exact panic (\`panic: invalid sum types for account status\`) locally against a real uninit mainnet wallet via \`PrepareMigration\`, matching the reported production stack trace.
- [x] Confirmed the fix eliminates the panic for the same input.