### PR TITLE
added len method to the cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -62,6 +62,10 @@ func (c *Cache[K, V]) Delete(key K) {
 	c.cache.Delete(key)
 }
 
+func (c *Cache[K, V]) Len() int {
+	return c.cache.Len()
+}
+
 // Keys returns the keys of the cache. the order is relied on algorithms.
 func (c *Cache[K, V]) Keys() []K {
 	return c.cache.Keys()


### PR DESCRIPTION
Adds a `Len()` method to the generic `Cache` type, delegating to the underlying cache's `Len()`.