### PR TITLE
feat: add address_override to /v2/wallet/emulate

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -492,6 +492,12 @@
      "application/json": {
       "schema": {
        "properties": {
+        "address_override": {
+         "description": "Override the destination wallet address extracted from the BoC. Useful when the BoC was signed with a throwaway key and the real wallet address must be emulated against.",
+         "example": "0:97146a46acc2654y27947f14c4a4b14273e954f78bc017790b41208b0043200b",
+         "format": "address",
+         "type": "string"
+        },
         "boc": {
          "format": "cell",
          "type": "string"

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -3610,6 +3610,14 @@ components:
               boc:
                 type: string
                 format: cell
+              address_override:
+                type: string
+                format: address
+                description: >-
+                  Override the destination wallet address extracted from the BoC.
+                  Useful when the BoC was signed with a throwaway key and the real
+                  wallet address must be emulated against.
+                example: "0:97146a46acc2654y27947f14c4a4b14273e954f78bc017790b41208b0043200b"
               params:
                 type: array
                 description: additional per account configuration

--- a/pkg/api/event_handlers.go
+++ b/pkg/api/event_handlers.go
@@ -746,6 +746,14 @@ func (h *Handler) EmulateMessageToWallet(ctx context.Context, request *oas.Emula
 	if err != nil {
 		return nil, toError(http.StatusBadRequest, err)
 	}
+	if request.AddressOverride.IsSet() {
+		addr, err := tongo.ParseAddress(request.AddressOverride.Value)
+		if err != nil {
+			return nil, toError(http.StatusBadRequest, err)
+		}
+		walletAddress = &addr.ID
+		m.Info.ExtInMsgInfo.Dest = addr.ID.ToMsgAddress()
+	}
 	var code []byte
 	if account, err := h.storage.GetRawAccount(ctx, *walletAddress); err == nil && len(account.Code) > 0 {
 		code = account.Code

--- a/pkg/oas/oas_json_gen.go
+++ b/pkg/oas/oas_json_gen.go
@@ -17131,6 +17131,12 @@ func (s *EmulateMessageToWalletReq) encodeFields(e *jx.Encoder) {
 		e.Str(s.Boc)
 	}
 	{
+		if s.AddressOverride.Set {
+			e.FieldStart("address_override")
+			s.AddressOverride.Encode(e)
+		}
+	}
+	{
 		if s.Params != nil {
 			e.FieldStart("params")
 			e.ArrStart()
@@ -17142,9 +17148,10 @@ func (s *EmulateMessageToWalletReq) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfEmulateMessageToWalletReq = [2]string{
+var jsonFieldsNameOfEmulateMessageToWalletReq = [3]string{
 	0: "boc",
-	1: "params",
+	1: "address_override",
+	2: "params",
 }
 
 // Decode decodes EmulateMessageToWalletReq from json.
@@ -17167,6 +17174,16 @@ func (s *EmulateMessageToWalletReq) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"boc\"")
+			}
+		case "address_override":
+			if err := func() error {
+				s.AddressOverride.Reset()
+				if err := s.AddressOverride.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"address_override\"")
 			}
 		case "params":
 			if err := func() error {

--- a/pkg/oas/oas_schemas_gen.go
+++ b/pkg/oas/oas_schemas_gen.go
@@ -6187,6 +6187,9 @@ func (s *EmulateMessageToTraceReq) SetBoc(val string) {
 
 type EmulateMessageToWalletReq struct {
 	Boc string `json:"boc"`
+	// Override the destination wallet address extracted from the BoC. Useful when the BoC was signed
+	// with a throwaway key and the real wallet address must be emulated against.
+	AddressOverride OptString `json:"address_override"`
 	// Additional per account configuration.
 	Params []EmulateMessageToWalletReqParamsItem `json:"params"`
 }
@@ -6194,6 +6197,11 @@ type EmulateMessageToWalletReq struct {
 // GetBoc returns the value of Boc.
 func (s *EmulateMessageToWalletReq) GetBoc() string {
 	return s.Boc
+}
+
+// GetAddressOverride returns the value of AddressOverride.
+func (s *EmulateMessageToWalletReq) GetAddressOverride() OptString {
+	return s.AddressOverride
 }
 
 // GetParams returns the value of Params.
@@ -6204,6 +6212,11 @@ func (s *EmulateMessageToWalletReq) GetParams() []EmulateMessageToWalletReqParam
 // SetBoc sets the value of Boc.
 func (s *EmulateMessageToWalletReq) SetBoc(val string) {
 	s.Boc = val
+}
+
+// SetAddressOverride sets the value of AddressOverride.
+func (s *EmulateMessageToWalletReq) SetAddressOverride(val OptString) {
+	s.AddressOverride = val
 }
 
 // SetParams sets the value of Params.


### PR DESCRIPTION
Allow callers to override the destination wallet address extracted from the BoC before emulation. This lets clients that sign the message with a throwaway private key (random dest) emulate against the real on-chain wallet.

Both walletAddress (used for code lookup, FindActions, event, risk) and m.Info.ExtInMsgInfo.Dest (what the emulator re-derives the target account from) are rewritten when address_override is set.