### PR TITLE
fix(blockchain): don't shadow err in msg_sender.send retry loop

### DIFF
--- a/pkg/blockchain/msg_sender.go
+++ b/pkg/blockchain/msg_sender.go
@@ -170,7 +170,7 @@ func (ms *MsgSender) send(ctx context.Context, payload []byte) error {
 		// three hanging liteservers could block a request for ~180s, causing the
 		// caller (or an upstream proxy) to time out and receive an empty response.
 		ctx2, cancel := context.WithTimeout(ctx, 10*time.Second)
-		_, err := c.SendMessage(ctx2, payload)
+		_, err = c.SendMessage(ctx2, payload)
 		cancel()
 		if err == nil {
 			liteserverMessageSendMc.WithLabelValues(fmt.Sprintf("%d", serverNumber), "success", fmt.Sprintf("%d", i)).Inc()

--- a/pkg/blockchain/msg_sender_test.go
+++ b/pkg/blockchain/msg_sender_test.go
@@ -1,10 +1,13 @@
 package blockchain
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	"github.com/tonkeeper/tongo/config"
+	"github.com/tonkeeper/tongo/liteapi"
 )
 
 func TestMsgSender_dropExpiredBatches(t *testing.T) {
@@ -56,4 +59,27 @@ func TestMsgSender_dropExpiredBatches(t *testing.T) {
 			require.Equal(t, tt.wantBocs, gotBocs)
 		})
 	}
+}
+
+// TestMsgSender_send_AllAttemptsFail is a regression test: send() must
+// return the underlying error when every liteserver attempt fails, not
+// swallow it. It previously returned nil because `_, err := c.SendMessage(...)`
+// inside the retry loop shadowed the function-scoped err instead of assigning it.
+func TestMsgSender_send_AllAttemptsFail(t *testing.T) {
+	badServer := config.LiteServer{
+		Host: "127.0.0.1:1", // nothing listens here; connection must fail
+		Key:  "wQEUBFTZKUpFvUVWkT8vTsxRUKWZFqXOMpXFBS2ykRE=",
+	}
+	client, err := liteapi.NewClient(
+		liteapi.WithAsyncConnectionsInit(),
+		liteapi.WithLiteServers([]config.LiteServer{badServer}),
+	)
+	require.NoError(t, err)
+
+	ms := &MsgSender{sendingClients: []*liteapi.Client{client}}
+	sendCtx, sendCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer sendCancel()
+
+	err = ms.send(sendCtx, []byte("payload content is irrelevant to send()"))
+	require.Error(t, err, "send() must surface the failure, not swallow it")
 }


### PR DESCRIPTION
_, err := c.SendMessage(ctx2, payload) declared a loop-scoped err instead of assigning the function-scoped one, so send() returned nil (i.e. success) whenever every liteserver attempt failed, causing /v2/blockchain/message to report 200 OK for messages that were never actually sent.