### PR TITLE
fix: remove 9000 cap on offset for GET /v2/jettons/{account_id}/holders

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -10742,7 +10742,6 @@
       "required": false,
       "schema": {
        "default": 0,
-       "maximum": 9000,
        "minimum": 0,
        "type": "integer"
       }

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -1652,7 +1652,6 @@ paths:
             type: integer
             default: 0
             minimum: 0
-            maximum: 9000
       responses:
         '200':
           description: jetton's holders

--- a/pkg/oas/oas_parameters_gen.go
+++ b/pkg/oas/oas_parameters_gen.go
@@ -8097,8 +8097,8 @@ func decodeGetJettonHoldersParams(args [1]string, argsEscaped bool, r *http.Requ
 						if err := (validate.Int{
 							MinSet:        true,
 							Min:           0,
-							MaxSet:        true,
-							Max:           9000,
+							MaxSet:        false,
+							Max:           0,
 							MinExclusive:  false,
 							MaxExclusive:  false,
 							MultipleOfSet: false,


### PR DESCRIPTION
The maximum was set at the spec level and enforced by generated request validation, rejecting offsets above 9000 before the handler ever ran. Neither the handler nor the underlying SQL query impose any bound of their own, so there's no reason to cap pagination depth here.