### PR TITLE
perf: batch /v2/jettons enrichment into GetJettonMasters, resolve offset pagination via storage

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -10638,7 +10638,7 @@
       }
      },
      {
-      "description": "Deprecated: served from a cache, so results may lag behind real-time. Use `last_account_id` for live, real-time pagination instead.",
+      "description": "Deprecated: pagination is based on a daily snapshot, so some new jettons may not appear yet. Use `last_account_id` for real-time pagination instead.",
       "in": "query",
       "name": "offset",
       "schema": {

--- a/api/openapi.yml
+++ b/api/openapi.yml
@@ -1588,8 +1588,8 @@ paths:
         - name: offset
           in: query
           description: >-
-            Deprecated: served from a cache, so results may lag behind real-time. Use `last_account_id` for
-            live, real-time pagination instead.
+            Deprecated: pagination is based on a daily snapshot, so some new jettons may not appear yet.
+            Use `last_account_id` for real-time pagination instead.
           schema:
             type: integer
             format: int32

--- a/pkg/api/handler.go
+++ b/pkg/api/handler.go
@@ -79,10 +79,6 @@ type Handler struct {
 	mu         sync.Mutex
 	dns        *dns.DNS // todo: update when blockchain config changes
 	configPool *sync.Pool
-
-	// jettonMasters serves legacy offset-based /v2/jettons requests. May be nil, in which case
-	// offset-based requests fail rather than being silently served as page one.
-	jettonMasters jettonMastersOffsetSource
 }
 
 func (h *Handler) NewError(ctx context.Context, err error) *oas.ErrorStatusCode {
@@ -112,8 +108,6 @@ type Options struct {
 	parallelTraceProcessing bool
 	archiveLiteServers      []config.LiteServer
 	publicAPIURL            string
-
-	jettonMastersOffsetSource jettonMastersOffsetSource
 }
 
 type Option func(o *Options)
@@ -222,14 +216,6 @@ func WithPublicAPIURL(publicAPIURL string) Option {
 	}
 }
 
-// WithJettonMastersOffsetSource registers the source used to serve legacy offset-based
-// /v2/jettons requests. When not set, offset-based requests fail with an error.
-func WithJettonMastersOffsetSource(source jettonMastersOffsetSource) Option {
-	return func(o *Options) {
-		o.jettonMastersOffsetSource = source
-	}
-}
-
 func NewHandler(logger *zap.Logger, opts ...Option) (*Handler, error) {
 	options := &Options{}
 	for _, o := range opts {
@@ -333,13 +319,16 @@ func NewHandler(logger *zap.Logger, opts ...Option) (*Handler, error) {
 		configPool:              configPool,
 		rewards:                 rwd,
 		stats:                   rewards.NewStats(liteapi.WithLiteServers(options.archiveLiteServers)),
-		jettonMasters:           options.jettonMastersOffsetSource,
 	}, nil
 }
 
 func (h *Handler) GetJettonNormalizedMetadata(ctx context.Context, master tongo.AccountID) NormalizedMetadata {
 	meta, _ := h.metaCache.getJettonMeta(ctx, master)
 	// TODO: should we ignore the second returned value?
+	return h.normalizeJettonMetadata(master, meta)
+}
+
+func (h *Handler) normalizeJettonMetadata(master tongo.AccountID, meta tep64.Metadata) NormalizedMetadata {
 	if info, ok := h.addressBook.GetJettonInfoByAddress(master); ok {
 		return NormalizeMetadata(master, meta, &info, core.TrustNone)
 	}

--- a/pkg/api/interfaces.go
+++ b/pkg/api/interfaces.go
@@ -102,6 +102,7 @@ type storage interface {
 	GetSubscriptionsV2(ctx context.Context, address tongo.AccountID) ([]core.SubscriptionV2, error)
 	GetSubscriptionsV1(ctx context.Context, address tongo.AccountID) ([]core.SubscriptionV1, error)
 	GetJettonMasters(ctx context.Context, limit int, lastAccountID *tongo.AccountID) ([]core.JettonMaster, error)
+	GetJettonMastersByOffset(ctx context.Context, limit, offset int) ([]core.JettonMaster, error)
 	GetJettonMastersByAddresses(ctx context.Context, addresses []ton.AccountID) ([]core.JettonMaster, error)
 
 	GetLastConfig(ctx context.Context) (ton.BlockchainConfig, error)
@@ -151,11 +152,6 @@ type liteStorageRaw interface {
 	GetConfigAllRaw(ctx context.Context, mode uint32, id tongo.BlockIDExt) (liteclient.LiteServerConfigInfoC, error)
 	GetShardBlockProofRaw(ctx context.Context, id tongo.BlockIDExt) (liteclient.LiteServerShardBlockProofC, error)
 	GetOutMsgQueueSizes(ctx context.Context) (liteclient.LiteServerOutMsgQueueSizesC, error)
-}
-
-// jettonMastersOffsetSource serves legacy offset-based /v2/jettons pagination without ever running an OFFSET query against storage
-type jettonMastersOffsetSource interface {
-	Slice(limit, offset int) []core.JettonMaster
 }
 
 // chainState provides current blockchain state which change very rarely or slow like staking APY income
@@ -238,13 +234,15 @@ type collectionMeta struct {
 	Owner *tongo.AccountID
 }
 
+type metadataStorage interface {
+	GetJettonMasterMetadata(ctx context.Context, master tongo.AccountID) (tep64.Metadata, error)
+	GetNftCollectionByCollectionAddress(ctx context.Context, address tongo.AccountID) (core.NftCollection, error)
+}
+
 type metadataCache struct {
 	collectionsCache cache.Cache[tongo.AccountID, collectionMeta]
 	jettonsCache     cache.Cache[tongo.AccountID, tep64.Metadata]
-	storage          interface {
-		GetJettonMasterMetadata(ctx context.Context, master tongo.AccountID) (tep64.Metadata, error)
-		GetNftCollectionByCollectionAddress(ctx context.Context, address tongo.AccountID) (core.NftCollection, error)
-	}
+	storage          metadataStorage
 }
 
 type mempoolEmulate struct {

--- a/pkg/api/jetton_converters.go
+++ b/pkg/api/jetton_converters.go
@@ -219,7 +219,12 @@ func (h *Handler) convertJettonBalance(ctx context.Context, wallet core.JettonWa
 }
 
 func (h *Handler) convertJettonInfo(ctx context.Context, master core.JettonMaster, holders map[tongo.AccountID]int32, scaledUiParams *core.ScaledUIParameters) oas.JettonInfo {
-	meta := h.GetJettonNormalizedMetadata(ctx, master.Address)
+	var meta NormalizedMetadata
+	if master.Enriched != nil {
+		meta = h.normalizeJettonMetadata(master.Address, master.Enriched.Metadata)
+	} else {
+		meta = h.GetJettonNormalizedMetadata(ctx, master.Address)
+	}
 	metadata := jettonMetadata(master.Address, meta)
 	info := oas.JettonInfo{
 		Mintable:     master.Mintable,
@@ -249,8 +254,14 @@ func (h *Handler) convertJettonInfo(ctx context.Context, master core.JettonMaste
 	if ab.Name != "" {
 		info.SetName(oas.NewOptNilString(ab.Name))
 	}
-	rawAccount, _ := h.storage.GetRawAccount(ctx, master.Address)
-	if rawAccount != nil && len(rawAccount.Interfaces) != 0 {
+	if master.Enriched != nil {
+		if len(master.Enriched.Interfaces) != 0 {
+			info.Interfaces = make([]string, len(master.Enriched.Interfaces))
+			for i, v := range master.Enriched.Interfaces {
+				info.Interfaces[i] = v.String()
+			}
+		}
+	} else if rawAccount, _ := h.storage.GetRawAccount(ctx, master.Address); rawAccount != nil && len(rawAccount.Interfaces) != 0 {
 		info.Interfaces = make([]string, len(rawAccount.Interfaces))
 		for i, v := range rawAccount.Interfaces {
 			info.Interfaces[i] = v.String()

--- a/pkg/api/jetton_handlers.go
+++ b/pkg/api/jetton_handlers.go
@@ -209,13 +209,8 @@ func (h *Handler) GetJettons(ctx context.Context, params oas.GetJettonsParams) (
 		}
 		jettons, err = h.storage.GetJettonMasters(ctx, limit, &account.ID)
 	case params.Offset.IsSet() && params.Offset.Value > 0:
-		if h.jettonMasters != nil {
-			offset := max(int(params.Offset.Value), 0)
-			jettons = h.jettonMasters.Slice(limit, offset)
-		} else {
-			h.logger.Error("received an offset-based /v2/jettons request, but no jettonMastersOffsetSource is configured")
-			return nil, toError(http.StatusInternalServerError, fmt.Errorf("offset-based pagination is currently not available"))
-		}
+		offset := max(int(params.Offset.Value), 0)
+		jettons, err = h.storage.GetJettonMastersByOffset(ctx, limit, offset)
 	default:
 		jettons, err = h.storage.GetJettonMasters(ctx, limit, nil)
 	}
@@ -232,9 +227,14 @@ func (h *Handler) GetJettons(ctx context.Context, params oas.GetJettonsParams) (
 	}
 	results := make([]oas.JettonInfo, len(jettons))
 	for idx, master := range jettons {
-		scaledUiParams, err := h.storage.GetScaledUIParameters(ctx, master.Address, nil)
-		if err != nil {
-			return nil, toError(http.StatusInternalServerError, err)
+		var scaledUiParams *core.ScaledUIParameters
+		if master.Enriched == nil {
+			scaledUiParams, err = h.storage.GetScaledUIParameters(ctx, master.Address, nil)
+			if err != nil {
+				return nil, toError(http.StatusInternalServerError, err)
+			}
+		} else {
+			scaledUiParams = master.Enriched.ScaledUI
 		}
 		results[idx] = h.convertJettonInfo(ctx, master, holders, scaledUiParams)
 	}
@@ -379,9 +379,14 @@ func (h *Handler) GetJettonInfosByAddresses(ctx context.Context, request oas.Opt
 	}
 	results := make([]oas.JettonInfo, len(jettons))
 	for idx, master := range jettons {
-		scaledUiParams, err := h.storage.GetScaledUIParameters(ctx, master.Address, nil)
-		if err != nil {
-			return nil, toError(http.StatusInternalServerError, err)
+		var scaledUiParams *core.ScaledUIParameters
+		if master.Enriched == nil {
+			scaledUiParams, err = h.storage.GetScaledUIParameters(ctx, master.Address, nil)
+			if err != nil {
+				return nil, toError(http.StatusInternalServerError, err)
+			}
+		} else {
+			scaledUiParams = master.Enriched.ScaledUI
 		}
 		results[idx] = h.convertJettonInfo(ctx, master, jettonsHolders, scaledUiParams)
 	}

--- a/pkg/core/jetton.go
+++ b/pkg/core/jetton.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 
 	"github.com/tonkeeper/tongo/abi"
+	"github.com/tonkeeper/tongo/tep64"
 	"github.com/tonkeeper/tongo/ton"
 
 	"github.com/shopspring/decimal"
@@ -28,6 +29,12 @@ type JettonHolder struct {
 	Balance       decimal.Decimal
 }
 
+type JettonMasterRich struct {
+	Metadata   tep64.Metadata
+	Interfaces []abi.ContractInterface
+	ScaledUI   *ScaledUIParameters
+}
+
 type JettonMaster struct {
 	// Address of a jetton master.
 	Address           tongo.AccountID
@@ -37,6 +44,8 @@ type JettonMaster struct {
 	CodeHash          string
 	DataHash          string
 	LastTransactionLt uint64
+	// Enriched might be populated to avoid N+1 db lookups (atm the GetJettonMasters does it)
+	Enriched *JettonMasterRich
 }
 
 type JettonWalletLockData struct {

--- a/pkg/litestorage/jetton.go
+++ b/pkg/litestorage/jetton.go
@@ -188,6 +188,11 @@ func (s *LiteStorage) GetJettonMasters(ctx context.Context, limit int, lastAccou
 	return []core.JettonMaster{}, nil
 }
 
+func (s *LiteStorage) GetJettonMastersByOffset(ctx context.Context, limit, offset int) ([]core.JettonMaster, error) {
+	// TODO: implement
+	return []core.JettonMaster{}, nil
+}
+
 func (s *LiteStorage) GetJettonMastersByAddresses(ctx context.Context, addresses []ton.AccountID) ([]core.JettonMaster, error) {
 	return []core.JettonMaster{}, nil
 }

--- a/pkg/oas/oas_parameters_gen.go
+++ b/pkg/oas/oas_parameters_gen.go
@@ -8317,8 +8317,8 @@ func decodeGetJettonTransferPayloadParams(args [2]string, argsEscaped bool, r *h
 // GetJettonsParams is parameters of getJettons operation.
 type GetJettonsParams struct {
 	Limit OptInt32 `json:",omitempty,omitzero"`
-	// Deprecated: served from a cache, so results may lag behind real-time. Use `last_account_id` for
-	// live, real-time pagination instead.
+	// Deprecated: pagination is based on a daily snapshot, so some new jettons may not appear yet. Use
+	// `last_account_id` for real-time pagination instead.
 	Offset OptInt32 `json:",omitempty,omitzero"`
 	// Cursor for pagination, always resolved live. Pass the `metadata.address` of the last jetton master
 	// from the previous page to get the next page. Preferred over `offset`.


### PR DESCRIPTION
## Summary
- Eliminates per-item N+1 lookups in `GetJettons`/`GetJettonInfosByAddresses` (metadata, interfaces, scaled-UI, raw account) by relying on a single batched `GetJettonMasters`/`GetJettonMastersByAddresses` query on the storage side (see the companion tonapi2 PR).
- `JettonMaster.Enriched` is now a `*JettonMasterRich` pointer (`Metadata`, `Interfaces`, `ScaledUI`) instead of a bare `bool` plus three flat fields, so "not enriched" is just `nil` rather than a bool you have to remember to check alongside three other fields.
- Offset-based `/v2/jettons` pagination is served through a plain `storage.GetJettonMastersByOffset` method instead of a separate `jettonMastersOffsetSource`/`WithJettonMastersOffsetSource` indirection.

## Test plan
- [ ] `go build ./...`
- [ ] `go vet ./...`
- [ ] Deployed together with the companion tonapi2 change to dev and exercised `/v2/jettons` (cursor and offset) and `/v2/jettons/_bulk`