### PR TITLE
fix: return 404 for not initialized accounts

### DIFF
--- a/pkg/api/account_handlers.go
+++ b/pkg/api/account_handlers.go
@@ -556,6 +556,9 @@ func (h *Handler) BlockchainAccountInspect(ctx context.Context, params oas.Block
 	if err != nil {
 		return nil, toError(http.StatusInternalServerError, err)
 	}
+	if len(rawAccount.Code) == 0 {
+		return nil, toError(http.StatusNotFound, fmt.Errorf("account has no code"))
+	}
 	cells, err := boc.DeserializeBoc(rawAccount.Code)
 	if err != nil {
 		return nil, toError(http.StatusInternalServerError, err)


### PR DESCRIPTION
BlockchainAccountInspect fell through to boc.DeserializeBoc on an empty code slice for not-initialized accounts. Return 404 instead.