### PR TITLE
resolve unreviewed NFT items to TrustNone instead of TrustBlacklist

### DIFF
--- a/pkg/api/event_converters_test.go
+++ b/pkg/api/event_converters_test.go
@@ -17,8 +17,8 @@ import (
 type mockSpamFilter struct {
 	blacklist map[ton.AccountID]bool
 	// nftTrust, when set, is returned verbatim by NftTrust; otherwise NftTrust mirrors the
-	// production rules that matter to converters (inherit the collection trust, and blacklist
-	// an item nothing vouches for).
+	// production rules that matter to converters (inherit the collection trust, and resolve
+	// to TrustNone when nothing vouches for the item).
 	nftTrust        core.TrustType
 	collectionTrust core.TrustType
 }
@@ -55,7 +55,7 @@ func (m mockSpamFilter) NftTrust(address tongo.AccountID, collection, owner *ton
 		return m.nftTrust
 	}
 	if collection == nil || collectionTrust == "" || collectionTrust == core.TrustNone {
-		return core.TrustBlacklist
+		return core.TrustNone
 	}
 	return collectionTrust
 }

--- a/pkg/api/interfaces.go
+++ b/pkg/api/interfaces.go
@@ -215,9 +215,8 @@ type SpamFilter interface {
 	TonDomainTrust(domain string) core.TrustType
 	// NftTrust resolves the trust of a single NFT item. collectionTrust is the trust of the
 	// collection the item belongs to (core.TrustNone when the item has no collection), so a
-	// scam collection taints every item in it. An implementation may blacklist an item that
-	// nothing vouches for, so callers must apply a reviewed status of their own (see
-	// convertNFT) before falling back to this.
+	// scam collection taints every item in it. An item that is neither whitelisted, graylisted,
+	// nor blacklisted resolves to core.TrustNone, same as every other Trust method.
 	NftTrust(address tongo.AccountID, collection, owner *ton.AccountID, collectionTrust core.TrustType, name, description, image string) core.TrustType
 	// NftCollectionTrust resolves the trust of an NFT collection itself.
 	NftCollectionTrust(address tongo.AccountID, owner *ton.AccountID, name, description, image string) core.TrustType

--- a/pkg/api/nft_converters.go
+++ b/pkg/api/nft_converters.go
@@ -88,8 +88,7 @@ func (h *Handler) convertNFT(ctx context.Context, item core.NftItem, book addres
 		nftItem.Trust = oas.TrustType(core.TrustWhitelist)
 	case trustType == core.TrustWhitelist || trustType == core.TrustGraylist:
 		// The item has been reviewed and cleared (support graylisted it, for instance). That
-		// verdict wins over every heuristic, including the spam filter blacklisting NFTs that
-		// nothing vouches for.
+		// verdict wins over whatever the spam filter's heuristics would otherwise return.
 		nftItem.Trust = oas.TrustType(trustType)
 	default:
 		nftTrust := h.spamFilter.NftTrust(item.Address, item.CollectionAddress, item.OwnerAddress, collectionTrust, name, description, image)

--- a/pkg/api/nft_converters_test.go
+++ b/pkg/api/nft_converters_test.go
@@ -26,8 +26,8 @@ func newTestMetaCache(collections map[ton.AccountID]collectionMeta) metadataCach
 }
 
 // TestConvertNFTTrust locks in how the NFT trust sources are combined: an item nothing vouches
-// for is blacklisted so clients blur it, an item inherits the trust of its collection, and a
-// review — support graylisting the item, or the address book approving it — keeps it visible.
+// for resolves to TrustNone, an item inherits the trust of its collection, and a review —
+// support graylisting the item, or the address book approving it — keeps it visible.
 func TestConvertNFTTrust(t *testing.T) {
 	nftID := ton.MustParseAccountID("EQCNmNR28mDfkwn4bwAlwJ1uhEFnjSQTZ3REz9d7IGZXU9EZ")
 	collectionID := ton.MustParseAccountID("EQDaaxtmY6Dk0YzIV0zNnbUpbjZ92TJHBvO72esc0srwv8K2")
@@ -44,14 +44,14 @@ func TestConvertNFTTrust(t *testing.T) {
 		expectedTrust   oas.TrustType
 	}{
 		{
-			name:          "NFT without a collection is a scam",
+			name:          "NFT without a collection is unreviewed",
 			collection:    nil,
-			expectedTrust: oas.TrustType(core.TrustBlacklist),
+			expectedTrust: oas.TrustType(core.TrustNone),
 		},
 		{
-			name:          "NFT in an unreviewed collection is blacklisted so clients blur it",
+			name:          "NFT in an unreviewed collection is unreviewed",
 			collection:    &collectionID,
-			expectedTrust: oas.TrustType(core.TrustBlacklist),
+			expectedTrust: oas.TrustType(core.TrustNone),
 		},
 		{
 			name:            "NFT inherits a blacklisted collection",


### PR DESCRIPTION
An item with no whitelist/graylist/blacklist match and no vouching collection/owner/heuristic now resolves to core.TrustNone, matching every other Trust method (accounts, domains, jettons, collections).